### PR TITLE
WAL-5 - Add MQTT connection test button with Android 6+ support

### DIFF
--- a/WallPanelPro/build.gradle
+++ b/WallPanelPro/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-parcelize'
     id 'kotlin-kapt' // Allows for Kotlin annotation processors
+    id 'com.github.sgtsilvio.gradle.android-retrofix' version '0.5.0'
 }
 
 def versionMajor = 1
@@ -224,8 +225,11 @@ dependencies {
     // MQTT
     implementation 'com.hivemq:hivemq-mqtt-client:1.3.2'
     implementation 'com.koushikdutta.async:androidasync:2.1.9'
-    implementation 'net.sourceforge.streamsupport:android-retrostreams:1.7.4'
-    implementation 'net.sourceforge.streamsupport:android-retrofuture:1.7.4'
+    
+    // RetroFix backport for HiveMQ on Android API < 24 (Android 6 and below)
+    // Backports CompletableFuture, Streams, and other Java 8 APIs
+    retrofix 'net.sourceforge.streamsupport:android-retrostreams:1.7.4'
+    retrofix 'net.sourceforge.streamsupport:android-retrofuture:1.7.4'
 
     // Logging
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/MqttSettingsFragment.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/MqttSettingsFragment.kt
@@ -19,6 +19,8 @@ package xyz.wallpanel.pro.ui.fragments
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.text.InputType
 import android.view.*
 import androidx.core.view.MenuProvider
@@ -27,10 +29,14 @@ import androidx.preference.SwitchPreference
 import androidx.preference.EditTextPreference
 import androidx.navigation.Navigation
 import androidx.preference.ListPreference
+import androidx.preference.Preference
 import xyz.wallpanel.pro.R
 import xyz.wallpanel.pro.network.MQTTOptions
+import xyz.wallpanel.pro.modules.MQTTModule
 import xyz.wallpanel.pro.ui.activities.SettingsActivity
 import dagger.android.support.AndroidSupportInjection
+import timber.log.Timber
+import java.util.concurrent.Executors
 import javax.inject.Inject
 
 class MqttSettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedPreferenceChangeListener  {
@@ -50,6 +56,12 @@ class MqttSettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedP
     private var mqttDiscoveryTopic: EditTextPreference? = null
     private var mqttDiscoveryDeviceName: EditTextPreference? = null
     private var mqttDiscoveryLegacyEntities: SwitchPreference? = null
+    private var mqttTestConnection: Preference? = null
+    
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val testExecutor = Executors.newSingleThreadExecutor()
+    private var testMqttModule: MQTTModule? = null
+    private var isTestingConnection = false
 
     private val sslPreference: SwitchPreference by lazy {
         findPreference<SwitchPreference>(PREF_TLS_CONNECTION) as SwitchPreference
@@ -106,10 +118,17 @@ class MqttSettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedP
         mqttDiscoveryTopic = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_discovery_topic)) as EditTextPreference
         mqttDiscoveryDeviceName = findPreference<EditTextPreference>(getString(R.string.key_setting_mqtt_discovery_name)) as EditTextPreference
         mqttDiscoveryLegacyEntities = findPreference<SwitchPreference>(getString(R.string.key_setting_mqtt_discovery_legacy_entities)) as SwitchPreference
+        mqttTestConnection = findPreference<Preference>(getString(R.string.key_setting_mqtt_test_connection)) as Preference
 
         mqttPassword?.setOnBindEditTextListener {editText ->
             // mask password in edit dialog
             editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
+        
+        // Set up test connection button click listener
+        mqttTestConnection?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            testMqttConnection()
+            true
         }
 
         bindPreferenceSummaryToValue(mqttPreference!!)
@@ -144,6 +163,205 @@ class MqttSettingsFragment : BaseSettingsFragment(), SharedPreferences.OnSharedP
                 }
             }
         }
+    }
+    
+    private fun testMqttConnection() {
+        if (isTestingConnection) {
+            Timber.d("Test already in progress")
+            return
+        }
+        
+        try {
+            Timber.d("=== Starting MQTT connection test ===")
+            isTestingConnection = true
+            
+            dialogUtils.showAlertDialogToDismiss(
+                requireActivity() as SettingsActivity,
+                "Testing Connection",
+                "Connecting to MQTT broker...\nThis may take a few seconds."
+            )
+            
+            testExecutor.execute {
+                try {
+                    val testOptions = MQTTOptions(configuration)
+                    Timber.d("Test options created: broker=${testOptions.getBroker()}, port=${testOptions.getPort()}")
+                    
+                    // Quick validation
+                    val validationErrors = mutableListOf<String>()
+                    if (testOptions.getBroker().isEmpty()) validationErrors.add("Broker address is empty")
+                    if (testOptions.getPort() <= 0) validationErrors.add("Invalid port")
+                    if (testOptions.getClientId().isEmpty()) validationErrors.add("Client ID is empty")
+                    
+                    if (validationErrors.isNotEmpty()) {
+                        mainHandler.post {
+                            showTestResult(false, "Validation Failed", validationErrors.joinToString("\n"))
+                            isTestingConnection = false
+                        }
+                        return@execute
+                    }
+                    
+                    // Create test listener
+                    val testListener = object : MQTTModule.MQTTListener {
+                        override fun onMQTTConnect() {
+                            Timber.d("MQTT Connected successfully!")
+                            mainHandler.post {
+                                showTestResult(true, "Connection Successful", 
+                                    "Successfully connected to MQTT broker!\n\n" +
+                                    "Broker: ${testOptions.getBroker()}\n" +
+                                    "Port: ${testOptions.getPort()}\n" +
+                                    "Client ID: ${testOptions.getClientId()}\n" +
+                                    "TLS: ${if (testOptions.getTlsConnection()) "Enabled" else "Disabled"}\n" +
+                                    "Version: ${testOptions.getVersion()}\n" +
+                                    "Auth: ${if (testOptions.getUsername().isNotEmpty()) "Yes" else "No"}")
+                                // Disconnect after successful test
+                                mainHandler.postDelayed({ cleanupTest() }, 1000)
+                            }
+                        }
+                        
+                        override fun onMQTTDisconnect() {
+                            Timber.d("MQTT Disconnected")
+                        }
+                        
+                        override fun onMQTTException(message: String) {
+                            val fullError = "=== MQTT CONNECTION TEST ERROR ===\n" +
+                                "Broker: ${testOptions.getBroker()}\n" +
+                                "Port: ${testOptions.getPort()}\n" +
+                                "Client ID: ${testOptions.getClientId()}\n" +
+                                "TLS: ${testOptions.getTlsConnection()}\n" +
+                                "Version: ${testOptions.getVersion()}\n" +
+                                "Username: ${testOptions.getUsername()}\n" +
+                                "Error: $message\n" +
+                                "==================================="
+                            Timber.e(fullError)
+                            mainHandler.post {
+                                showTestResult(false, "Connection Failed", 
+                                    "Broker: ${testOptions.getBroker()}:${testOptions.getPort()}\n" +
+                                    "Client ID: ${testOptions.getClientId()}\n" +
+                                    "TLS: ${testOptions.getTlsConnection()}\n" +
+                                    "MQTT Version: ${testOptions.getVersion()}\n" +
+                                    "Username: ${if (testOptions.getUsername().isNotEmpty()) testOptions.getUsername() else "(none)"}\n\n" +
+                                    "ERROR:\n$message")
+                                cleanupTest()
+                            }
+                        }
+                        
+                        override fun onMQTTMessage(id: String, topic: String, payload: String) {
+                            Timber.d("Test received message: $topic")
+                        }
+                    }
+                    
+                    // Use MQTTModule to test connection
+                    Timber.d("Creating MQTTModule with version ${testOptions.getVersion()}")
+                    testMqttModule = MQTTModule(requireContext().applicationContext, testOptions, testListener)
+                    testMqttModule?.restart() // Start the connection
+                    
+                    // Set timeout
+                    mainHandler.postDelayed({
+                        if (isTestingConnection) {
+                            Timber.w("Connection test timeout")
+                            showTestResult(false, "Connection Timeout", 
+                                "Failed to connect within 15 seconds.\n\n" +
+                                "Please check:\n" +
+                                "- Broker address is correct\n" +
+                                "- Port is correct\n" +
+                                "- Broker is running and accessible\n" +
+                                "- Network connection is available\n" +
+                                "- Firewall allows connection")
+                            cleanupTest()
+                        }
+                    }, 15000)
+                    
+                } catch (e: Throwable) {
+                    val fullError = "=== MQTT CONNECTION TEST EXCEPTION ===\n" +
+                        "Exception Type: ${e.javaClass.simpleName}\n" +
+                        "Message: ${e.message}\n" +
+                        "Cause: ${e.cause?.message ?: "None"}\n" +
+                        "Stack Trace:\n${e.stackTraceToString()}\n" +
+                        "======================================="
+                    Timber.e(e, fullError)
+                    mainHandler.post {
+                        val errorDetail = buildString {
+                            appendLine("Exception: ${e.javaClass.simpleName}")
+                            appendLine()
+                            if (e.message != null) {
+                                appendLine("Message: ${e.message}")
+                                appendLine()
+                            }
+                            if (e.cause != null) {
+                                appendLine("Cause: ${e.cause?.javaClass?.simpleName}")
+                                appendLine("  ${e.cause?.message}")
+                                appendLine()
+                            }
+                            appendLine("Stack trace (first 10 lines):")
+                            val stackLines = e.stackTraceToString().lines().take(10)
+                            stackLines.forEach { appendLine("  $it") }
+                        }
+                        showTestResult(false, "Test Error", errorDetail)
+                        cleanupTest()
+                    }
+                }
+            }
+            
+        } catch (e: Throwable) {
+            val criticalError = "=== MQTT TEST CRITICAL ERROR ===\n" +
+                "Exception Type: ${e.javaClass.simpleName}\n" +
+                "Message: ${e.message}\n" +
+                "Cause: ${e.cause?.message ?: "None"}\n" +
+                "Stack Trace:\n${e.stackTraceToString()}\n" +
+                "================================="
+            Timber.e(e, criticalError)
+            val errorDetail = buildString {
+                appendLine("Critical Error: ${e.javaClass.simpleName}")
+                appendLine()
+                if (e.message != null) {
+                    appendLine(e.message!!)
+                    appendLine()
+                }
+                if (e.cause != null) {
+                    appendLine("Caused by: ${e.cause?.javaClass?.simpleName}")
+                    appendLine("  ${e.cause?.message}")
+                }
+            }
+            showTestResult(false, "Critical Error", errorDetail)
+            isTestingConnection = false
+        }
+    }
+    
+    private fun showTestResult(success: Boolean, title: String, message: String) {
+        try {
+            dialogUtils.showAlertDialogToDismiss(
+                requireActivity() as SettingsActivity,
+                title,
+                message
+            )
+        } catch (e: Exception) {
+            Timber.e(e, "Cannot show test result dialog")
+        }
+    }
+    
+    private fun cleanupTest() {
+        Timber.d("Cleaning up test connection")
+        isTestingConnection = false
+        
+        testExecutor.execute {
+            try {
+                testMqttModule?.pause()
+                testMqttModule = null
+                Timber.d("Test MQTT module cleaned up")
+            } catch (e: Exception) {
+                Timber.e(e, "Error cleaning up test MQTT module")
+            }
+        }
+    }
+    
+    override fun onDestroyView() {
+        cleanupTest()
+        super.onDestroyView()
+    }
+    
+    override fun onDestroy() {
+        testExecutor.shutdown()
+        super.onDestroy()
     }
 
     companion object {

--- a/WallPanelPro/src/main/res/values/donottranslate.xml
+++ b/WallPanelPro/src/main/res/values/donottranslate.xml
@@ -51,6 +51,7 @@
     <string name="key_setting_mqtt_discovery_name">setting_mqtt_discovery_name</string>
     <string name="key_setting_mqtt_discovery_legacy_entities">setting_mqtt_discovery_legacy_entities</string>
     <string name="key_setting_mqtt_tls_enabled">key_setting_mqtt_tls_enabled</string>
+    <string name="key_setting_mqtt_test_connection">setting_mqtt_test_connection</string>
     <string name="default_setting_mqtt_enabled">false</string>
     <string name="default_setting_mqtt_version">5.0</string>
     <string name="default_setting_mqtt_home_assistant_discovery">false</string>

--- a/WallPanelPro/src/main/res/values/strings.xml
+++ b/WallPanelPro/src/main/res/values/strings.xml
@@ -76,6 +76,11 @@
     <string name="title_setting_mqtt_discovery_legacy_entities">Use old entities naming</string>
     <string name="summary_setting_mqtt_discovery_legacy_entities">Use old naming scheme for Home Assistant before 2023.08</string>
     <string name="default_setting_mqtt_home_assistant_name">My Wall Panel</string>
+    <string name="title_setting_mqtt_test_connection">Test Connection</string>
+    <string name="summary_setting_mqtt_test_connection">Test connection to MQTT broker</string>
+    <string name="message_mqtt_test_testing">Testing MQTT connection...</string>
+    <string name="message_mqtt_test_success">Successfully connected to MQTT broker!</string>
+    <string name="message_mqtt_test_failed">Failed to connect to MQTT broker</string>
     <string name="title_setting_android_startonboot">Open On Device Boot</string>
     <string name="title_setting_android_browsertype">Specify Browser Engine</string>
     <string name="default_setting_android_browsertype">Auto</string>

--- a/WallPanelPro/src/main/res/xml/pref_mqtt.xml
+++ b/WallPanelPro/src/main/res/xml/pref_mqtt.xml
@@ -95,6 +95,12 @@
             android:summary="@string/preference_summary_client_id"
             android:title="@string/title_setting_mqtt_clientid" />
 
+        <Preference
+            android:key="@string/key_setting_mqtt_test_connection"
+            android:title="@string/title_setting_mqtt_test_connection"
+            android:summary="@string/summary_setting_mqtt_test_connection"
+            android:dependency="@string/key_setting_mqtt_enabled" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_category_mqtt_discovery">


### PR DESCRIPTION
### Added
- **MQTT Connection Test Button** in Settings -> MQTT
  - Tests the actual connection to the MQTT broker with authentication
  - Displays detailed connection info on success
  - Shows comprehensive error messages with connection details on failure
  - 15-second timeout with helpful troubleshooting suggestions
  - Proper cleanup after test completion

### Fixed
- **Android 6 support for HiveMQ MQTT client**
  - Implemented RetroFix plugin to backport Java 8 APIs (`CompletableFuture`, Streams)
  - MQTT connections now work on Android 5.0+ (API 21+)
  - Added `android-retrostreams` and `android-retrofuture` backport libraries
  - Fixed `NoClassDefFoundError` on older Android versions
