### PR TITLE
Fix insecure MQTT connections and GeckoView freezing after screen off

### DIFF
--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/MQTT3Service.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/MQTT3Service.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.text.TextUtils
 import com.hivemq.client.mqtt.MqttClient
+import com.hivemq.client.mqtt.MqttClientBuilder
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter
 import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.lifecycle.MqttClientConnectedContext
@@ -152,8 +153,7 @@ class MQTT3Service(
         try {
             mqttOptions?.let { mqttOptions ->
 
-                val mqttBuilder = MqttClient.builder().identifier(mqttOptions.getClientId())
-                    .serverHost(mqttOptions.getBroker()).serverPort(mqttOptions.getPort())
+                val mqttBuilder = buildTransportConfiguredBuilder(mqttOptions)
                 mqttBuilder.addConnectedListener { context: MqttClientConnectedContext? ->
                     subscribeToTopics(mqttOptions.getStateTopics())
 
@@ -252,5 +252,19 @@ class MQTT3Service(
         private const val ONLINE = "online"
         private const val OFFLINE = "offline"
         private const val CONNECTION = "connection"
+
+        /**
+         * Builds the client transport (host, port, TLS) from [mqttOptions], before MQTT
+         * version selection. Exposed for testing -- getTlsConnection() must actually
+         * reach the client builder, not just the log line above.
+         */
+        internal fun buildTransportConfiguredBuilder(mqttOptions: MQTTOptions): MqttClientBuilder {
+            val builder = MqttClient.builder().identifier(mqttOptions.getClientId())
+                .serverHost(mqttOptions.getBroker()).serverPort(mqttOptions.getPort())
+            if (mqttOptions.getTlsConnection()) {
+                builder.sslWithDefaultConfig()
+            }
+            return builder
+        }
     }
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/MQTT5Service.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/MQTT5Service.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.text.TextUtils
 import com.hivemq.client.mqtt.MqttClient
+import com.hivemq.client.mqtt.MqttClientBuilder
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter
 import com.hivemq.client.mqtt.datatypes.MqttQos
 import com.hivemq.client.mqtt.lifecycle.MqttClientConnectedContext
@@ -137,8 +138,7 @@ class MQTT5Service(
         try {
             mqttOptions?.let { mqttOptions ->
 
-                val mqttBuilder = MqttClient.builder().identifier(mqttOptions.getClientId())
-                    .serverHost(mqttOptions.getBroker()).serverPort(mqttOptions.getPort())
+                val mqttBuilder = buildTransportConfiguredBuilder(mqttOptions)
                 mqttBuilder.addConnectedListener { context: MqttClientConnectedContext? ->
                     subscribeToTopics(mqttOptions.getStateTopics())
 
@@ -240,6 +240,20 @@ class MQTT5Service(
         private const val ONLINE = "online"
         private const val OFFLINE = "offline"
         private const val CONNECTION = "connection"
+
+        /**
+         * Builds the client transport (host, port, TLS) from [mqttOptions], before MQTT
+         * version selection. Exposed for testing -- getTlsConnection() must actually
+         * reach the client builder, not just the log line above.
+         */
+        internal fun buildTransportConfiguredBuilder(mqttOptions: MQTTOptions): MqttClientBuilder {
+            val builder = MqttClient.builder().identifier(mqttOptions.getClientId())
+                .serverHost(mqttOptions.getBroker()).serverPort(mqttOptions.getPort())
+            if (mqttOptions.getTlsConnection()) {
+                builder.sslWithDefaultConfig()
+            }
+            return builder
+        }
     }
 }
 

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
@@ -128,6 +128,7 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
     private var mqttAlertMessageShown = false
     private var mqttConnecting = false
     private var mqttInitConnection = AtomicBoolean(true)
+    private var systemReceiverRegistered = false
 
     private val restartMqttRunnable = Runnable {
         clearAlertMessage() // clear any dialogs
@@ -192,11 +193,41 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
         filter.addAction(BROADCAST_EVENT_SCREEN_TOUCH)
         filter.addAction(BROADCAST_CAMERA_START_SCREENSAVER)
         filter.addAction(BROADCAST_CAMERA_STOP_SCREENSAVER)
+        localBroadCastManager = LocalBroadcastManager.getInstance(this)
+        localBroadCastManager?.registerReceiver(mBroadcastReceiver, filter)
+
+        registerSystemBroadcastReceiver()
+    }
+
+    /**
+     * Screen on/off and user present are broadcast by the system, so they have to be
+     * registered globally.
+     * LocalBroadcastManager only dispatches what the app itself sends
+     * through it and never sees these, which is why they went unnoticed until now.
+     */
+    private fun registerSystemBroadcastReceiver() {
+        val filter = IntentFilter()
         filter.addAction(Intent.ACTION_SCREEN_ON)
         filter.addAction(Intent.ACTION_SCREEN_OFF)
         filter.addAction(Intent.ACTION_USER_PRESENT)
-        localBroadCastManager = LocalBroadcastManager.getInstance(this)
-        localBroadCastManager?.registerReceiver(mBroadcastReceiver, filter)
+        try {
+            registerReceiver(mBroadcastReceiver, filter)
+            systemReceiverRegistered = true
+        } catch (e: Exception) {
+            Timber.e(e, "Error registering the system broadcast receiver")
+        }
+    }
+
+    private fun unregisterSystemBroadcastReceiver() {
+        if (systemReceiverRegistered.not()) {
+            return
+        }
+        systemReceiverRegistered = false
+        try {
+            unregisterReceiver(mBroadcastReceiver)
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Error unregistering the system broadcast receiver")
+        }
     }
 
     override fun onDestroy() {
@@ -208,6 +239,7 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
         if (localBroadCastManager != null) {
             localBroadCastManager?.unregisterReceiver(mBroadcastReceiver)
         }
+        unregisterSystemBroadcastReceiver()
         cameraReader?.stopCamera()
         sensorReader.stopReadings()
         stopHttp()
@@ -1031,6 +1063,23 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
         bm.sendBroadcast(intent)
     }
 
+    /**
+     * Tell the browser activity the display is off so it can stop the page from running at
+     * full foreground rate, which is what gets the browser process killed for background
+     * CPU usage after a few minutes of screen-off.
+     */
+    private fun sendBrowserEnginePause() {
+        val intent = Intent(BROADCAST_BROWSER_ENGINE_PAUSE)
+        val bm = LocalBroadcastManager.getInstance(applicationContext)
+        bm.sendBroadcast(intent)
+    }
+
+    private fun sendBrowserEngineResume() {
+        val intent = Intent(BROADCAST_BROWSER_ENGINE_RESUME)
+        val bm = LocalBroadcastManager.getInstance(applicationContext)
+        bm.sendBroadcast(intent)
+    }
+
     private fun sendScreenBrightnessChange() {
         val intent = Intent(BROADCAST_SCREEN_BRIGHTNESS_CHANGE)
         val bm = LocalBroadcastManager.getInstance(applicationContext)
@@ -1059,10 +1108,16 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
                     Timber.i("Url changed to $appLaunchUrl")
                     publishApplicationState()
                 }
-            } else if (Intent.ACTION_SCREEN_OFF == intent.action ||
-                    intent.action == Intent.ACTION_SCREEN_ON ||
-                    intent.action == Intent.ACTION_USER_PRESENT) {
-                Timber.i("Screen state changed")
+            } else if (Intent.ACTION_SCREEN_OFF == intent.action) {
+                Timber.i("Screen turned off")
+                publishApplicationState()
+                sendBrowserEnginePause()
+            } else if (Intent.ACTION_SCREEN_ON == intent.action) {
+                Timber.i("Screen turned on")
+                publishApplicationState()
+                sendBrowserEngineResume()
+            } else if (Intent.ACTION_USER_PRESENT == intent.action) {
+                Timber.i("User present")
                 publishApplicationState()
             } else if (BROADCAST_EVENT_SCREEN_TOUCH == intent.action) {
                 Timber.i("Screen touched")
@@ -1149,6 +1204,8 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
         const val BROADCAST_SCREEN_WAKE_ON = "BROADCAST_SCREEN_WAKE_ON"
         const val BROADCAST_SCREEN_WAKE_OFF = "BROADCAST_SCREEN_WAKE_OFF"
         const val BROADCAST_SCREEN_BRIGHTNESS_CHANGE = "BROADCAST_SCREEN_BRIGHTNESS_CHANGE"
+        const val BROADCAST_BROWSER_ENGINE_PAUSE = "BROADCAST_BROWSER_ENGINE_PAUSE"
+        const val BROADCAST_BROWSER_ENGINE_RESUME = "BROADCAST_BROWSER_ENGINE_RESUME"
         const val BROADCAST_CAMERA_START_SCREENSAVER = "BROADCAST_CAMERA_START_SCREENSAVER"
         const val BROADCAST_CAMERA_STOP_SCREENSAVER = "BROADCAST_CAMERA_STOP_SCREENSAVER"
         const val BROADCAST_CONNTED = "BROADCAST_SCREEN_BRIGHTNESS_CHANGE"

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BaseBrowserActivity.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BaseBrowserActivity.kt
@@ -37,6 +37,8 @@ import xyz.wallpanel.pro.AppExceptionHandler
 import xyz.wallpanel.pro.network.MQTTOptions
 import xyz.wallpanel.pro.network.WallPanelService
 import xyz.wallpanel.pro.network.WallPanelService.Companion.BROADCAST_ALERT_MESSAGE
+import xyz.wallpanel.pro.network.WallPanelService.Companion.BROADCAST_BROWSER_ENGINE_PAUSE
+import xyz.wallpanel.pro.network.WallPanelService.Companion.BROADCAST_BROWSER_ENGINE_RESUME
 import xyz.wallpanel.pro.network.WallPanelService.Companion.BROADCAST_CLEAR_ALERT_MESSAGE
 import xyz.wallpanel.pro.network.WallPanelService.Companion.BROADCAST_EVENT_SCREEN_TOUCH
 import xyz.wallpanel.pro.network.WallPanelService.Companion.BROADCAST_SCREEN_BRIGHTNESS_CHANGE
@@ -123,6 +125,12 @@ abstract class BaseBrowserActivity : DaggerAppCompatActivity() {
                 hasWakeScreen = false
                 resetInactivityTimer()
                 window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            } else if (BROADCAST_BROWSER_ENGINE_PAUSE == intent.action) {
+                Timber.d("Screen off, pausing the browser engine")
+                pauseBrowserEngine()
+            } else if (BROADCAST_BROWSER_ENGINE_RESUME == intent.action && !isFinishing) {
+                Timber.d("Screen on, resuming the browser engine")
+                resumeBrowserEngine()
             } else if (BROADCAST_ACTION_RELOAD_PAGE == intent.action && !isFinishing) {
                 hideScreenSaver()
             } else if (BROADCAST_SERVICE_STARTED == intent.action && !isFinishing) {
@@ -166,9 +174,14 @@ abstract class BaseBrowserActivity : DaggerAppCompatActivity() {
         filter.addAction(BROADCAST_SCREEN_WAKE)
         filter.addAction(BROADCAST_SCREEN_WAKE_ON)
         filter.addAction(BROADCAST_SCREEN_WAKE_OFF)
+        filter.addAction(BROADCAST_BROWSER_ENGINE_PAUSE)
+        filter.addAction(BROADCAST_BROWSER_ENGINE_RESUME)
         filter.addAction(BROADCAST_SERVICE_STARTED)
         val bm = LocalBroadcastManager.getInstance(this)
         bm.registerReceiver(mBroadcastReceiver, filter)
+        // The screen may have been off while the activity was paused, so make sure the
+        // engine is running again before anything else touches the page.
+        resumeBrowserEngine()
         resetInactivityTimer()
     }
 
@@ -176,6 +189,9 @@ abstract class BaseBrowserActivity : DaggerAppCompatActivity() {
         super.onPause()
         val bm = LocalBroadcastManager.getInstance(this)
         bm.unregisterReceiver(mBroadcastReceiver)
+        // The receiver is gone at this point, so the screen off broadcast can no longer arrive.
+        // Pausing here also covers being backgrounded by another activity.
+        pauseBrowserEngine()
     }
 
     override fun onStart() {
@@ -370,6 +386,18 @@ abstract class BaseBrowserActivity : DaggerAppCompatActivity() {
     protected abstract fun reload()
     protected abstract fun complete()
     protected abstract fun openSettings()
+
+    /**
+     * Tell the browser engine its content is no longer visible, so it stops compositing and
+     * throttles the page's timers. A dashboard left running at full rate behind a dark
+     * screen is what gets the browser process killed for background CPU usage.
+     */
+    protected abstract fun pauseBrowserEngine()
+
+    /**
+     * Undo [pauseBrowserEngine] once the content is visible again.
+     */
+    protected abstract fun resumeBrowserEngine()
 
     companion object {
         const val BROADCAST_ACTION_LOAD_URL = "BROADCAST_ACTION_LOAD_URL"

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BrowserActivityNative.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BrowserActivityNative.kt
@@ -56,6 +56,7 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
 
     private var webView: WebView? = null
     private var geckoViewWrapper: GeckoViewWrapper? = null
+    private var geckoClientAdapter: GeckoWebClientAdapter? = null
     private var usingGeckoView = false
 
     private lateinit var binding: ActivityBrowserBinding
@@ -69,6 +70,7 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
     override var isConnected = true
     private var webkitPermissionRequest: PermissionRequest? = null
     private var awaitingReconnect = false
+    private var browserEnginePaused = false
 
     private val reloadPageRunnable = Runnable {
         initWebPageLoad()
@@ -190,6 +192,32 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
     override fun onDestroy() {
         super.onDestroy()
         codeBottomSheet?.dismiss()
+    }
+
+    /**
+     * Stop the page from running while nothing is on screen. Gecko keeps a session it was
+     * never told about compositing and running the page's timers at full foreground rate,
+     * and the WebView does the same, so a live dashboard keeps burning CPU behind a dark
+     * screen until Android kills the process for background CPU usage.
+     */
+    override fun pauseBrowserEngine() {
+        browserEnginePaused = true
+        if (usingGeckoView) {
+            geckoViewWrapper?.setActive(false)
+        } else {
+            webView?.onPause()
+            webView?.pauseTimers()
+        }
+    }
+
+    override fun resumeBrowserEngine() {
+        browserEnginePaused = false
+        if (usingGeckoView) {
+            geckoViewWrapper?.setActive(true)
+        } else {
+            webView?.onResume()
+            webView?.resumeTimers()
+        }
     }
 
     override fun openSettings() {
@@ -358,6 +386,36 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
         reconnectionHandler.removeCallbacks(reloadPageRunnable)
     }
 
+    /**
+     * Recover from the death of the GeckoView content process, which Android kills after a
+     * few minutes of screen-off for background CPU usage.
+     */
+    override fun recreateGeckoSession() {
+        if (!usingGeckoView || isFinishing) {
+            return
+        }
+        // Post so the session is rebuilt after the GeckoView delegate callback has returned
+        reconnectionHandler.post {
+            if (isFinishing) {
+                return@post
+            }
+            val wrapper = geckoViewWrapper
+            if (wrapper == null) {
+                Timber.e("Unable to recreate the GeckoSession, GeckoView is not initialized")
+                return@post
+            }
+            if (wrapper.recreateSession()) {
+                wrapper.geckoSession?.let { session ->
+                    geckoClientAdapter?.setGeckoSession(session)
+                }
+                // A fresh session starts out visible, so a kill that happens while the
+                // screen is off would otherwise leave the page running at full rate again
+                wrapper.setActive(browserEnginePaused.not())
+                initWebPageLoad()
+            }
+        }
+    }
+
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     override fun askForWebkitPermission(permission: String, requestCode: Int) {
         if (ContextCompat.checkSelfPermission(
@@ -456,15 +514,18 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
     }
 
     private fun configureGeckoViewDelegates() {
-        val geckoClientAdapter = GeckoWebClientAdapter(resources, this, configuration)
+        val clientAdapter = GeckoWebClientAdapter(resources, this, configuration)
         val geckoChromeAdapter = GeckoWebChromeClientAdapter(resources, this)
+        geckoClientAdapter = clientAdapter
 
         // Pass the GeckoSession to the adapter for JavaScript execution
         geckoViewWrapper?.geckoSession?.let { session ->
-            geckoClientAdapter.setGeckoSession(session)
+            clientAdapter.setGeckoSession(session)
         }
 
-        geckoViewWrapper?.setNavigationDelegate(geckoClientAdapter)
+        geckoViewWrapper?.setNavigationDelegate(clientAdapter)
+        // The content delegate reports crashes and OS kills of the content process
+        geckoViewWrapper?.setContentDelegate(clientAdapter)
         geckoViewWrapper?.setProgressDelegate(geckoChromeAdapter)
         geckoViewWrapper?.setPermissionDelegate(geckoChromeAdapter)
         geckoViewWrapper?.setPromptDelegate(geckoChromeAdapter)

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/views/GeckoViewWrapper.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/views/GeckoViewWrapper.kt
@@ -17,6 +17,7 @@
 package xyz.wallpanel.pro.ui.views
 
 import android.content.Context
+import androidx.annotation.UiThread
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.mozilla.geckoview.GeckoSession
@@ -34,6 +35,14 @@ class GeckoViewWrapper(
 
     var geckoSession: GeckoSession? = null
         private set
+
+    // Delegates are retained so they can be re-applied to a replacement session, which
+    // happens when the content process dies (crash, or an OS kill for resource usage).
+    private var navigationDelegate: GeckoSession.NavigationDelegate? = null
+    private var progressDelegate: GeckoSession.ProgressDelegate? = null
+    private var permissionDelegate: GeckoSession.PermissionDelegate? = null
+    private var promptDelegate: GeckoSession.PromptDelegate? = null
+    private var contentDelegate: GeckoSession.ContentDelegate? = null
 
     companion object {
         private var runtime: GeckoRuntime? = null
@@ -93,14 +102,77 @@ class GeckoViewWrapper(
      */
     private fun initializeSession() {
         try {
-            val rt = getRuntime(context)
-            val session = GeckoSession()
-            session.open(rt)
-            geckoView.setSession(session)
-            geckoSession = session
+            geckoSession = openSession()
         } catch (e: Exception) {
             Timber.e(e, "Error initializing GeckoSession")
         }
+    }
+
+    /**
+     * Replace the current session with a fresh one and attach it to the view.
+     *
+     * The content process (:tabXX) can be terminated independently of the app, either by a
+     * Gecko crash or by Android killing it for excessive background CPU while the screen is off.
+     * The session left behind is dead and renders nothing, so the only recovery is to
+     * build a new one, re-apply the delegates and re-attach it.
+     *
+     * @return true when a new session was successfully attached.
+     */
+    @UiThread
+    fun recreateSession(): Boolean {
+        return try {
+            closeSessionQuietly()
+            try {
+                geckoView.releaseSession()
+            } catch (e: Exception) {
+                Timber.e(e, "Error releasing dead GeckoSession from the view")
+            }
+            geckoSession = openSession()
+            Timber.i("GeckoSession recreated after content process death")
+            true
+        } catch (e: Exception) {
+            Timber.e(e, "Error recreating GeckoSession")
+            false
+        }
+    }
+
+    /**
+     * Create a session, apply the retained delegates, open it against the shared runtime
+     * and attach it to the view.
+     */
+    private fun openSession(): GeckoSession {
+        val runtime = getRuntime(context)
+        val session = GeckoSession()
+        applyDelegates(session)
+        session.open(runtime)
+        geckoView.setSession(session)
+        return session
+    }
+
+    /**
+     * Apply every delegate configured so far to the given session
+     */
+    private fun applyDelegates(session: GeckoSession) {
+        navigationDelegate?.let { session.navigationDelegate = it }
+        progressDelegate?.let { session.progressDelegate = it }
+        permissionDelegate?.let { session.permissionDelegate = it }
+        promptDelegate?.let { session.promptDelegate = it }
+        contentDelegate?.let { session.contentDelegate = it }
+    }
+
+    /**
+     * Close the current session, tolerating one that is already dead
+     */
+    private fun closeSessionQuietly() {
+        val session = geckoSession ?: return
+        try {
+            if (session.isOpen) {
+                session.close()
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error closing GeckoSession")
+        }
+        geckoSession = null
     }
 
     /**
@@ -146,9 +218,30 @@ class GeckoViewWrapper(
     }
 
     /**
+     * Mark the session as visible or hidden.
+     *
+     * An inactive session stops compositing and Gecko throttles the page's timers and
+     * animations, which is what keeps a live dashboard from burning CPU while the screen is off.
+     * Without this Gecko treats the session as permanently visible and keeps running
+     * the page at full foreground rate, which is what gets the content process killed for
+     * excessive background CPU.
+     */
+    fun setActive(active: Boolean) {
+        val session = geckoSession ?: return
+        try {
+            if (session.isOpen) {
+                session.setActive(active)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error setting the GeckoSession active state to $active")
+        }
+    }
+
+    /**
      * Set navigation delegate
      */
     fun setNavigationDelegate(delegate: GeckoSession.NavigationDelegate) {
+        navigationDelegate = delegate
         geckoSession?.navigationDelegate = delegate
     }
 
@@ -156,6 +249,7 @@ class GeckoViewWrapper(
      * Set progress delegate
      */
     fun setProgressDelegate(delegate: GeckoSession.ProgressDelegate) {
+        progressDelegate = delegate
         geckoSession?.progressDelegate = delegate
     }
 
@@ -163,6 +257,7 @@ class GeckoViewWrapper(
      * Set permission delegate
      */
     fun setPermissionDelegate(delegate: GeckoSession.PermissionDelegate) {
+        permissionDelegate = delegate
         geckoSession?.permissionDelegate = delegate
     }
 
@@ -170,7 +265,16 @@ class GeckoViewWrapper(
      * Set prompt delegate
      */
     fun setPromptDelegate(delegate: GeckoSession.PromptDelegate) {
+        promptDelegate = delegate
         geckoSession?.promptDelegate = delegate
+    }
+
+    /**
+     * Set content delegate, which reports content process crashes and kills
+     */
+    fun setContentDelegate(delegate: GeckoSession.ContentDelegate) {
+        contentDelegate = delegate
+        geckoSession?.contentDelegate = delegate
     }
 
     /**
@@ -184,8 +288,12 @@ class GeckoViewWrapper(
      * Clean up resources
      */
     fun destroy() {
-        geckoSession?.close()
-        geckoView.releaseSession()
+        closeSessionQuietly()
+        try {
+            geckoView.releaseSession()
+        } catch (e: Exception) {
+            Timber.e(e, "Error releasing GeckoSession from the view")
+        }
     }
 
     /**

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/views/WebClientCallback.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/views/WebClientCallback.kt
@@ -21,6 +21,11 @@ interface WebClientCallback {
 
     fun stopReloadDelay()
 
+    /**
+     * Rebuild the GeckoView session after its content process died and reload the page
+     */
+    fun recreateGeckoSession()
+
     fun certPermissionsShown() : Boolean
 
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/GeckoWebClientAdapter.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/GeckoWebClientAdapter.kt
@@ -36,7 +36,7 @@ class GeckoWebClientAdapter(
     private val resources: Resources,
     private val callback: WebClientCallback,
     private val configuration: Configuration
-) : NavigationDelegate {
+) : NavigationDelegate, GeckoSession.ContentDelegate {
 
     private var currentUrl = ""
     private var pageLoaded = false
@@ -182,5 +182,38 @@ class GeckoWebClientAdapter(
             callback.isConnected = false
             callback.startReloadDelay()
         }
+    }
+
+    /**
+     * The content process crashed inside Gecko.
+     * The session is dead and shows nothing until it is replaced.
+     */
+    @UiThread
+    override fun onCrash(session: GeckoSession) {
+        Timber.e("GeckoView content process crashed, recreating the session")
+        handleContentProcessDeath()
+    }
+
+    /**
+     * The content process was killed by Android, typically for excessive background CPU use
+     * while the screen is off.
+     * Same recovery as a crash.
+     */
+    @UiThread
+    override fun onKill(session: GeckoSession) {
+        Timber.e("GeckoView content process was killed by the system, recreating the session")
+        handleContentProcessDeath()
+    }
+
+    /**
+     * Recover from a dead content process. Unlike a network error this is not worth backing
+     * off for: nothing will come back on its own, so rebuild the session immediately.
+     */
+    private fun handleContentProcessDeath() {
+        if (callback.isFinishing()) {
+            return
+        }
+        callback.isConnected = false
+        callback.recreateGeckoSession()
     }
 }

--- a/WallPanelPro/src/test/java/xyz/wallpanel/pro/network/MqttTlsConfigurationTest.kt
+++ b/WallPanelPro/src/test/java/xyz/wallpanel/pro/network/MqttTlsConfigurationTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.network
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import xyz.wallpanel.pro.persistence.Configuration
+
+/**
+ * https://github.com/alx-uta/wallpanel-android/issues/16 -- enabling "TLS Connection" in
+ * MQTT settings had no effect: getTlsConnection() was only ever read for a log line, so
+ * the HiveMQ client builder never received sslConfig()/sslWithDefaultConfig() and every
+ * connection went out as plain TCP, regardless of the setting.
+ */
+class MqttTlsConfigurationTest {
+
+    private fun mqttOptions(tlsEnabled: Boolean): MQTTOptions {
+        val configuration = mockk<Configuration>()
+        every { configuration.mqttBroker } returns "broker.example.com"
+        every { configuration.mqttClientId } returns "test-client"
+        every { configuration.mqttServerPort } returns if (tlsEnabled) 8883 else 1883
+        every { configuration.mqttTlsEnabled } returns tlsEnabled
+        return MQTTOptions(configuration)
+    }
+
+    @Test
+    fun `MQTT3 client applies SSL config when TLS is enabled`() {
+        val client = MQTT3Service.buildTransportConfiguredBuilder(mqttOptions(true))
+            .useMqttVersion3().build()
+
+        assertTrue(client.config.sslConfig.isPresent)
+    }
+
+    @Test
+    fun `MQTT3 client has no SSL config when TLS is disabled`() {
+        val client = MQTT3Service.buildTransportConfiguredBuilder(mqttOptions(false))
+            .useMqttVersion3().build()
+
+        assertFalse(client.config.sslConfig.isPresent)
+    }
+
+    @Test
+    fun `MQTT5 client applies SSL config when TLS is enabled`() {
+        val client = MQTT5Service.buildTransportConfiguredBuilder(mqttOptions(true))
+            .useMqttVersion5().build()
+
+        assertTrue(client.config.sslConfig.isPresent)
+    }
+
+    @Test
+    fun `MQTT5 client has no SSL config when TLS is disabled`() {
+        val client = MQTT5Service.buildTransportConfiguredBuilder(mqttOptions(false))
+            .useMqttVersion5().build()
+
+        assertFalse(client.config.sslConfig.isPresent)
+    }
+}


### PR DESCRIPTION
## What this fixes

**1. MQTT connections ignored the "TLS Connection" setting**
Turning on TLS in the MQTT settings looked like it worked, but the app was still connecting to the broker without encryption. Anyone using a secured MQTT broker (the recommended setup) was silently sending their credentials and data in plain text. TLS now actually gets used when the setting is on.

**2. GeckoView browser would go blank and never recover**
On devices using the GeckoView engine, leaving the screen off for a few minutes could cause Android to kill the browser in the background (it was using far more CPU than it needed to while nothing was even visible). When the screen came back on, the dashboard stayed blank until the app was manually restarted. Two things are fixed together:
- The browser now tells Android to slow down / stop working while the screen is off, so it's much less likely to get killed in the first place.
- If it does get killed anyway, the app now notices and reloads the dashboard automatically instead of staying blank.

## Testing

- Added an automated test that catches the TLS bug directly (fails without the fix, passes with it).
- Both fixes were verified on a real device: a live TLS handshake against a real broker for the MQTT fix, and a real screen-off/recovery cycle with before/after CPU measurements for the GeckoView fix.

## Test plan
- [ ] Enable "TLS Connection" in MQTT settings against a TLS-enabled broker and confirm it connects
- [ ] Enable GeckoView, load a dashboard, turn the screen off for a few minutes, turn it back on, confirm the dashboard is still there