### PR TITLE
Fix CPU/Battery drain, brightness bug, and add shell-command permission handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For issues, feature requests, use the [Github issues tracker](https://github.com
 - MQTT or HTTP commands to remotely control device and application (url, brightness, wake, etc.).
 - Sensor data reporting for the device (temperature, light, pressure, battery, CPU usage, memory usage).
 - System resource monitoring with CPU and memory sensors for device health tracking.
-- Remote shell command execution via MQTT/HTTP (opt-in, security warning).
+- Remote shell command execution via MQTT/HTTP (opt-in, security warning, runs unprivileged -- see the [Shell Command docs](https://wallpanel.xyz/docs/remote-control/commands#shell-command) for what does and doesn't work).
 - Streaming MJPEG server support using the device camera.
 - Screensaver feature that can be dismissed with motion or face detection.
 - Support for Android 4.4 (API level 19) and greater devices.

--- a/WallPanelPro/build.gradle
+++ b/WallPanelPro/build.gradle
@@ -24,7 +24,7 @@ plugins {
 
 def versionMajor = 1
 def versionMinor = 1
-def versionPatch = 5
+def versionPatch = 6
 def versionBuild = 0 // bump for dog food builds, public betas, etc.
 
 // HA/MQTT test credentials for dev-flavor builds live in local.testconfig.properties

--- a/WallPanelPro/src/main/AndroidManifest.xml
+++ b/WallPanelPro/src/main/AndroidManifest.xml
@@ -17,6 +17,17 @@
         android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions" /> <!-- Optional supported features -->
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+    <!--
+      Only requested when the optional shell command feature is enabled, and only useful on
+      API 23-28. From API 29 scoped storage applies (targetSdkVersion 33), so these grant no
+      broad file access and are capped with maxSdkVersion.
+    -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <uses-feature
         android:name="android.hardware.audio.low_latency"
         android:required="false" />

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/SensorReader.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/SensorReader.kt
@@ -49,6 +49,9 @@ constructor(private val context: Context){
     private var callback: SensorCallback? = null
     private var sensorsPublished: Boolean = false
     private var lightSensorEvent: SensorEvent? = null
+    // Some devices' SELinux policy denies untrusted apps read access to /proc/stat.
+    // Once that's confirmed, stop retrying every cycle instead of failing forever.
+    private var cpuUsageUnavailable: Boolean = false
 
     private val sensorUpdateRunnable = object : Runnable {
         override fun run() {
@@ -56,7 +59,9 @@ constructor(private val context: Context){
                 getBatteryReading()
                 // Run CPU and memory reading on background thread to avoid StrictMode violations
                 Thread {
-                    getCpuUsage()
+                    if (!cpuUsageUnavailable) {
+                        getCpuUsage()
+                    }
                     getMemoryUsage()
                 }.start()
                 sensorHandler.postDelayed(this, updateFrequencyMilliSeconds.toLong())
@@ -294,6 +299,9 @@ constructor(private val context: Context){
                     publishSensorData(CPU_USAGE, data)
                 }
             }
+        } catch (e: java.io.FileNotFoundException) {
+            cpuUsageUnavailable = true
+            Timber.w("CPU usage unavailable on this device (cannot read /proc/stat): ${e.message}")
         } catch (e: Exception) {
             Timber.e(e, "Error reading CPU usage")
         }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
@@ -695,8 +695,24 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
 
     private fun executeShellCommand(command: String) {
         try {
-            val process = Runtime.getRuntime().exec(arrayOf("sh", "-c", command))
+            // stderr is merged into stdout so a single reader can drain the process, draining one
+            // pipe at a time would deadlock a command that fills the other pipe's buffer.
+            val process = ProcessBuilder("sh", "-c", command)
+                    .redirectErrorStream(true)
+                    .start()
+            // Drain the output before waiting, otherwise a full pipe buffer blocks the process.
+            val output = try {
+                process.inputStream.bufferedReader().use { it.readText() }.trim()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to read output of shell command: $command")
+                ""
+            }
             val exitCode = process.waitFor()
+            if (exitCode == 0) {
+                Timber.i("Shell command [$command] exited with code $exitCode, output: $output")
+            } else {
+                Timber.w("Shell command [$command] failed with exit code $exitCode, output: $output")
+            }
         } catch (e: Exception) {
             Timber.e(e, "Failed to execute shell command: $command")
         }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Configuration.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Configuration.kt
@@ -302,6 +302,18 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
             settingsUpdated()
         }
 
+    // How long the screen can stay off before the GeckoView session is torn down to stop
+    // background CPU use.
+    val geckoViewSuspendSeconds: Int
+        get() = try {
+            getStringPref(
+                R.string.key_use_geckoview_suspend_seconds,
+                R.string.default_use_geckoview_suspend_seconds
+            ).trim().toInt()
+        } catch (e: Exception) {
+            30
+        }
+
     val cameraFPS: Float
         get() = try {
             getStringPref(R.string.key_setting_camera_fps, R.string.default_camera_fps).trim().toFloat()

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Configuration.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Configuration.kt
@@ -77,6 +77,12 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
             sharedPreferences.edit().putBoolean(PREF_CAMERA_PERMISSIONS, value).apply()
         }
 
+    var shellPermissionsShown: Boolean
+        get() = sharedPreferences.getBoolean(PREF_SHELL_PERMISSIONS, false)
+        set(value) {
+            sharedPreferences.edit().putBoolean(PREF_SHELL_PERMISSIONS, value).apply()
+        }
+
     var cameraRotate: Float
         get() = this.sharedPreferences.getString(PREF_CAMERA_ROTATE, "0f")!!.toFloat()
         set(value) = this.sharedPreferences.edit().putString(PREF_CAMERA_ROTATE, value.toString()).apply()
@@ -431,6 +437,7 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
         const val PREF_FIRST_TIME = "pref_first_time"
         const val PREF_WRITE_SCREEN_PERMISSIONS = "pref_write_screen_permissions"
         const val PREF_CAMERA_PERMISSIONS = "pref_camera_permissions"
+        const val PREF_SHELL_PERMISSIONS = "pref_shell_permissions"
         const val PREF_CAMERA_ROTATE = "pref_camera_rotate"
         const val PREF_BROWSER_REFRESH_DISCONNECT = "pref_browser_refresh_disconnect"
         const val PREF_SCREEN_BRIGHTNESS = "pref_use_screen_brightness"

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BrowserActivityNative.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BrowserActivityNative.kt
@@ -71,9 +71,21 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
     private var webkitPermissionRequest: PermissionRequest? = null
     private var awaitingReconnect = false
     private var browserEnginePaused = false
+    private var pendingGeckoReloadOnResume = false
 
     private val reloadPageRunnable = Runnable {
         initWebPageLoad()
+    }
+
+    // Android kills a cached GeckoView content process for excessive background CPU after
+    // about 5 minutes; setActive(false) alone doesn't stop a websocket-driven dashboard from
+    // burning that CPU. Rather than wait to be killed, tear the session down deliberately
+    // once the screen has been off longer than the configured grace period.
+    private val geckoSuspendRunnable = Runnable {
+        if (!isFinishing && usingGeckoView && browserEnginePaused) {
+            geckoViewWrapper?.suspend()
+            pendingGeckoReloadOnResume = true
+        }
     }
 
     // To save current index
@@ -204,6 +216,14 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
         browserEnginePaused = true
         if (usingGeckoView) {
             geckoViewWrapper?.setActive(false)
+            reconnectionHandler.removeCallbacks(geckoSuspendRunnable)
+            val suspendDelaySeconds = configuration.geckoViewSuspendSeconds
+            if (suspendDelaySeconds > 0) {
+                reconnectionHandler.postDelayed(
+                    geckoSuspendRunnable,
+                    TimeUnit.SECONDS.toMillis(suspendDelaySeconds.toLong())
+                )
+            }
         } else {
             webView?.onPause()
             webView?.pauseTimers()
@@ -213,11 +233,33 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
     override fun resumeBrowserEngine() {
         browserEnginePaused = false
         if (usingGeckoView) {
+            reconnectionHandler.removeCallbacks(geckoSuspendRunnable)
             geckoViewWrapper?.setActive(true)
+            reloadGeckoIfPending()
         } else {
             webView?.onResume()
             webView?.resumeTimers()
         }
+    }
+
+    /**
+     * Bring the page back after either a deliberate suspend() (no session at all) or a
+     * recreateGeckoSession() that deferred its reload while the screen was off (an empty
+     * but open session).
+     * Either way the dashboard needs loading once the screen wakes.
+     */
+    private fun reloadGeckoIfPending() {
+        if (!pendingGeckoReloadOnResume) {
+            return
+        }
+        pendingGeckoReloadOnResume = false
+        val wrapper = geckoViewWrapper ?: return
+        if (wrapper.geckoSession == null && wrapper.recreateSession()) {
+            wrapper.geckoSession?.let { session ->
+                geckoClientAdapter?.setGeckoSession(session)
+            }
+        }
+        initWebPageLoad()
     }
 
     override fun openSettings() {
@@ -411,7 +453,14 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
                 // A fresh session starts out visible, so a kill that happens while the
                 // screen is off would otherwise leave the page running at full rate again
                 wrapper.setActive(browserEnginePaused.not())
-                initWebPageLoad()
+                if (browserEnginePaused) {
+                    // Reloading the dashboard behind a dark screen re-arms the CPU burn that
+                    // got the content process killed, so the empty session is left alone until
+                    // the screen comes back
+                    pendingGeckoReloadOnResume = true
+                } else {
+                    initWebPageLoad()
+                }
             }
         }
     }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/HttpSettingsFragment.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/HttpSettingsFragment.kt
@@ -16,9 +16,13 @@
 
 package xyz.wallpanel.pro.ui.fragments
 
+import android.Manifest
 import android.content.Context
 import android.content.Context.WIFI_SERVICE
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import android.net.wifi.WifiManager
+import android.os.Build
 import android.os.Bundle
 import androidx.preference.SwitchPreference
 import androidx.preference.EditTextPreference
@@ -28,6 +32,9 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.widget.Toast
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.navigation.Navigation
 import xyz.wallpanel.pro.R
 import xyz.wallpanel.pro.ui.activities.SettingsActivity
@@ -37,6 +44,7 @@ import dagger.android.support.AndroidSupportInjection
 class HttpSettingsFragment : BaseSettingsFragment() {
 
     private var httpRestPreference: SwitchPreference? = null
+    private var httpShellPreference: SwitchPreference? = null
     private var httpMjpegPreference: SwitchPreference? = null
     private var httpMjpegStreamsPreference: EditTextPreference? = null
     private var httpPortPreference: EditTextPreference? = null
@@ -89,11 +97,13 @@ class HttpSettingsFragment : BaseSettingsFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         httpRestPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_http_restenabled)) as SwitchPreference
+        httpShellPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_http_shellenabled)) as SwitchPreference
         httpMjpegPreference = findPreference<SwitchPreference>(getString(R.string.key_setting_http_mjpegenabled)) as SwitchPreference
         httpMjpegStreamsPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_http_mjpegmaxstreams)) as EditTextPreference
         httpPortPreference = findPreference<EditTextPreference>(getString(R.string.key_setting_http_port)) as EditTextPreference
 
         bindPreferenceSummaryToValue(httpRestPreference!!)
+        bindPreferenceSummaryToValue(httpShellPreference!!)
         bindPreferenceSummaryToValue(httpMjpegPreference!!)
         bindPreferenceSummaryToValue(httpMjpegStreamsPreference!!)
         bindPreferenceSummaryToValue(httpPortPreference!!)
@@ -103,5 +113,53 @@ class HttpSettingsFragment : BaseSettingsFragment() {
 
         val description = findPreference<Preference>(getString(R.string.key_setting_directions)) as Preference
         description.summary = getString(R.string.pref_mjpeg_streaming_description, ip )
+    }
+
+    /**
+     * Shell commands run as the application's own unprivileged user, so they only reach shared
+     * storage if the application itself holds the storage permissions. That is only meaningful
+     * on API 23 through 28: below that the permissions are granted at install time, and from
+     * API 29 scoped storage applies to this application, so requesting them would gain nothing.
+     */
+    private fun requestShellPermissions() {
+        if (Build.VERSION.SDK_INT in Build.VERSION_CODES.M..Build.VERSION_CODES.P && !configuration.shellPermissionsShown) {
+            if (PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(requireActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    || PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(requireActivity(), Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                configuration.shellPermissionsShown = true
+                ActivityCompat.requestPermissions(requireActivity(),
+                        arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE),
+                        PERMISSIONS_REQUEST_SHELL)
+            }
+        } else {
+            configuration.shellPermissionsShown = true
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        when (requestCode) {
+            PERMISSIONS_REQUEST_SHELL -> {
+                // If request is cancelled, the result arrays are empty.
+                if (grantResults.isNotEmpty() && grantResults.all { it == PackageManager.PERMISSION_GRANTED }) {
+                    Toast.makeText(requireContext(), R.string.toast_shell_permission_granted, Toast.LENGTH_LONG).show()
+                } else {
+                    // Shell commands stay enabled, only commands touching shared storage are limited.
+                    Toast.makeText(requireContext(), R.string.toast_shell_permission_denied, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        when (key) {
+            getString(R.string.key_setting_http_shellenabled) -> {
+                if (httpShellPreference?.isChecked == true) {
+                    requestShellPermissions()
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val PERMISSIONS_REQUEST_SHELL = 210
     }
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/SettingsFragment.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/SettingsFragment.kt
@@ -83,6 +83,7 @@ class SettingsFragment : BaseSettingsFragment() {
     private var screenBrightness: SwitchPreference? = null
     private var dimPreference: ListPreference? = null
     private var rotationPreference: EditTextPreference? = null
+    private var geckoSuspendPreference: EditTextPreference? = null
 
     private val fullScreenPreference: SwitchPreference by lazy {
         findPreference<SwitchPreference>(PREF_SETTINGS_FULL_SCREEN) as SwitchPreference
@@ -259,6 +260,11 @@ class SettingsFragment : BaseSettingsFragment() {
         rotationPreference?.summary = getString(R.string.preference_summary_image_rotation, configuration.imageRotation.toString())
         rotationPreference?.setDefaultValue(configuration.imageRotation.toString())
 
+        geckoSuspendPreference = findPreference(getString(R.string.key_use_geckoview_suspend_seconds))
+        geckoSuspendPreference?.text = configuration.geckoViewSuspendSeconds.toString()
+        geckoSuspendPreference?.summary = getString(R.string.summary_use_geckoview_suspend_seconds, configuration.geckoViewSuspendSeconds.toString())
+        geckoSuspendPreference?.setDefaultValue(configuration.geckoViewSuspendSeconds.toString())
+
         // Setup additional screensaver options
         webScreenSaver.isChecked = configuration.webScreenSaver
         dimScreensaver.isChecked = configuration.hasDimScreenSaver
@@ -429,6 +435,16 @@ class SettingsFragment : BaseSettingsFragment() {
                     if (rotation != null) {
                         configuration.imageRotation = rotation
                         rotationPreference?.summary = getString(R.string.preference_summary_image_rotation, rotation.toString())
+                    } else {
+                        Toast.makeText(requireContext(), getString(R.string.toast_error_bad_decimal), Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+            getString(R.string.key_use_geckoview_suspend_seconds) -> {
+                geckoSuspendPreference?.text?.let {
+                    val seconds = it.toIntOrNull()
+                    if (seconds != null && seconds >= 0) {
+                        geckoSuspendPreference?.summary = getString(R.string.summary_use_geckoview_suspend_seconds, seconds.toString())
                     } else {
                         Toast.makeText(requireContext(), getString(R.string.toast_error_bad_decimal), Toast.LENGTH_SHORT).show()
                     }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/views/GeckoViewWrapper.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/views/GeckoViewWrapper.kt
@@ -285,15 +285,24 @@ class GeckoViewWrapper(
     }
 
     /**
-     * Clean up resources
+     * Tear down the content process without opening a replacement. Unlike setActive(false),
+     * which merely throttles the page, this leaves no process behind to burn background CPU
+     * or be killed by Android. Call recreateSession() to bring the session back.
      */
-    fun destroy() {
+    fun suspend() {
         closeSessionQuietly()
         try {
             geckoView.releaseSession()
         } catch (e: Exception) {
             Timber.e(e, "Error releasing GeckoSession from the view")
         }
+    }
+
+    /**
+     * Clean up resources
+     */
+    fun destroy() {
+        suspend()
     }
 
     /**

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/GeckoWebChromeClientAdapter.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/GeckoWebChromeClientAdapter.kt
@@ -103,6 +103,12 @@ class GeckoWebChromeClientAdapter(
             GeckoSession.PermissionDelegate.PERMISSION_PERSISTENT_STORAGE -> {
                 return GeckoResult.fromValue(GeckoSession.PermissionDelegate.ContentPermission.VALUE_ALLOW)
             }
+            GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_INAUDIBLE -> {
+                return GeckoResult.fromValue(GeckoSession.PermissionDelegate.ContentPermission.VALUE_ALLOW)
+            }
+            GeckoSession.PermissionDelegate.PERMISSION_AUTOPLAY_AUDIBLE -> {
+                return GeckoResult.fromValue(GeckoSession.PermissionDelegate.ContentPermission.VALUE_ALLOW)
+            }
             else -> {
                 return GeckoResult.fromValue(GeckoSession.PermissionDelegate.ContentPermission.VALUE_DENY)
             }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/ScreenUtils.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/ScreenUtils.kt
@@ -67,9 +67,9 @@ constructor(context: Context, private val configuration: Configuration): Context
             val screenBrightness = configuration.screenBrightness
             val screenScreenBrightness = configuration.screenScreenSaverBrightness
             try {
-                if (screenBrightness in 1..255 && !screenSaver) {
+                if (screenBrightness in 0..255 && !screenSaver) {
                     Settings.System.putInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS, screenBrightness)
-                } else if (screenScreenBrightness in 1..255 && screenSaver) {
+                } else if (screenScreenBrightness in 0..255 && screenSaver) {
                     Settings.System.putInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS, screenScreenBrightness)
                 }
             } catch (e: SecurityException) {
@@ -82,7 +82,7 @@ constructor(context: Context, private val configuration: Configuration): Context
     fun updateScreenBrightness(brightness: Int) {
         if(canWriteScreenSetting()) {
             try {
-                if (brightness in 1..255) {
+                if (brightness in 0..255) {
                     Settings.System.putInt(contentResolver, Settings.System.SCREEN_BRIGHTNESS, brightness)
                     configuration.screenBrightness = brightness
                     if(configuration.screenSaverDimValue > 0) {

--- a/WallPanelPro/src/main/res/values/strings.xml
+++ b/WallPanelPro/src/main/res/values/strings.xml
@@ -331,6 +331,11 @@
     <string name="title_use_geckoview">Use GeckoView</string>
     <string name="summary_use_geckoview">Mozilla browser engine with modern web standards. Restart required.</string>
 
+    <string name="key_use_geckoview_suspend_seconds">pref_use_geckoview_suspend_seconds</string>
+    <string name="default_use_geckoview_suspend_seconds">30</string>
+    <string name="title_use_geckoview_suspend_seconds">GeckoView Background Suspend Delay</string>
+    <string name="summary_use_geckoview_suspend_seconds">Suspends GeckoView to stop background CPU use after the screen has been off this many seconds. Currently %1$s. 0 disables suspension.</string>
+
 
     <string-array name="flip_directions">
         <item>None</item>

--- a/WallPanelPro/src/main/res/values/strings.xml
+++ b/WallPanelPro/src/main/res/values/strings.xml
@@ -100,6 +100,8 @@
     <string name="button_launch_settings">Launch Settings</string>
     <string name="toast_camera_permission_granted">Camera permission granted.</string>
     <string name="toast_camera_permission_denied">Camera permission not granted.</string>
+    <string name="toast_shell_permission_granted">Storage permission granted.</string>
+    <string name="toast_shell_permission_denied">Storage permission not granted. Shell commands remain enabled, but commands that read or write shared storage may not work.</string>
     <string name="dialog_write_permissions_title">Permissions Required</string>
     <string name="dialog_write_permissions_description">Do you want to grant permission to modify the system settings for screen brightness?</string>
     <string name="pref_title_screen_brightness">Screen Brightness</string>

--- a/WallPanelPro/src/main/res/xml/pref_general.xml
+++ b/WallPanelPro/src/main/res/xml/pref_general.xml
@@ -83,6 +83,13 @@
             android:title="@string/title_use_geckoview"
             android:summary="@string/summary_use_geckoview"/>
 
+        <EditTextPreference
+            android:defaultValue="@string/default_use_geckoview_suspend_seconds"
+            android:key="@string/key_use_geckoview_suspend_seconds"
+            android:title="@string/title_use_geckoview_suspend_seconds"
+            android:summary="@string/summary_use_geckoview_suspend_seconds"
+            android:inputType="number"/>
+
         <SwitchPreference
             android:defaultValue="@string/default_setting_ignore_ssl_errors"
             android:key="@string/key_setting_ignore_ssl_errors"

--- a/WallPanelPro/src/main/res/xml/pref_http.xml
+++ b/WallPanelPro/src/main/res/xml/pref_http.xml
@@ -46,8 +46,7 @@
             android:defaultValue="@string/default_setting_http_shellenabled"
             android:key="@string/key_setting_http_shellenabled"
             android:title="Enable Shell Commands ( Security Risk )"
-            android:summary="Allow executing shell commands via HTTP API"
-            android:dependency="@string/key_setting_http_restenabled"/>
+            android:summary="Allow executing shell commands via HTTP or MQTT"/>
 
     </PreferenceCategory>
 

--- a/WallPanelPro/src/test/java/xyz/wallpanel/pro/persistence/ConfigurationTest.kt
+++ b/WallPanelPro/src/test/java/xyz/wallpanel/pro/persistence/ConfigurationTest.kt
@@ -22,6 +22,7 @@ import androidx.preference.PreferenceManager
 import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -76,5 +77,34 @@ class ConfigurationTest {
         every { fake.getBoolean(any(), any()) } returns false
 
         assertFalse(Configuration(context, fake).isFirstTime)
+    }
+
+    @Test
+    fun `geckoViewSuspendSeconds defaults to 30`() {
+        assertEquals(30, configuration.geckoViewSuspendSeconds)
+    }
+
+    @Test
+    fun `geckoViewSuspendSeconds round-trips through SharedPreferences`() {
+        val key = context.getString(xyz.wallpanel.pro.R.string.key_use_geckoview_suspend_seconds)
+        preferences.edit().putString(key, "10").commit()
+
+        assertEquals(10, configuration.geckoViewSuspendSeconds)
+    }
+
+    @Test
+    fun `geckoViewSuspendSeconds of 0 disables suspension without falling back to the default`() {
+        val key = context.getString(xyz.wallpanel.pro.R.string.key_use_geckoview_suspend_seconds)
+        preferences.edit().putString(key, "0").commit()
+
+        assertEquals(0, configuration.geckoViewSuspendSeconds)
+    }
+
+    @Test
+    fun `geckoViewSuspendSeconds falls back to 30 on a malformed value`() {
+        val key = context.getString(xyz.wallpanel.pro.R.string.key_use_geckoview_suspend_seconds)
+        preferences.edit().putString(key, "not-a-number").commit()
+
+        assertEquals(30, configuration.geckoViewSuspendSeconds)
     }
 }

--- a/website/docs/remote-control/commands.md
+++ b/website/docs/remote-control/commands.md
@@ -18,7 +18,7 @@ wake | true | ```{"wake": true, "wakeTime": 180}``` | Wakes the screen if it is 
 wake | false | ```{"wake": false}``` | Release screen wake (Note: screen will not turn off before Androids Display Timeout finished)
 speak | data | ```{"speak": "Hello!"}``` | Uses the devices TTS to speak the message
 settings | data | ```{"settings": true}``` | Opens the settings screen remotely.
-brightness | data | ```{"brightness": 1}``` | Changes the screens brightness, value 1-255.
+brightness | data | ```{"brightness": 1}``` | Changes the screens brightness, value 0-255 (0 turns the backlight off).
 camera | data | ```{"camera": true}``` | Turns on/off camera, this will also disable streaming, motion, QRCode, and face detection.
 volume | data | ```{"volume": 100}``` | Changes the audio volume, value 0-100 (in %. Does not effect TTS volume).
 shell | command | ```{"shell": "log -t WallPanel hello-from-wallpanel"}``` | Runs a shell command on the device. Opt-in and unprivileged -- see [Shell Command](#shell-command) below before relying on this.

--- a/website/docs/remote-control/commands.md
+++ b/website/docs/remote-control/commands.md
@@ -21,6 +21,7 @@ settings | data | ```{"settings": true}``` | Opens the settings screen remotely.
 brightness | data | ```{"brightness": 1}``` | Changes the screens brightness, value 1-255.
 camera | data | ```{"camera": true}``` | Turns on/off camera, this will also disable streaming, motion, QRCode, and face detection.
 volume | data | ```{"volume": 100}``` | Changes the audio volume, value 0-100 (in %. Does not effect TTS volume).
+shell | command | ```{"shell": "log -t WallPanel hello-from-wallpanel"}``` | Runs a shell command on the device. Opt-in and unprivileged -- see [Shell Command](#shell-command) below before relying on this.
 
 * The base topic value (default is "mywallpanel") should be unique to each device running the application unless you want all devices to receive the same command. The base topic and can be changed in the applications ```MQTT settings```.
 * Commands are constructed via valid JSON. It is possible to string multiple commands together:
@@ -31,6 +32,225 @@ volume | data | ```{"volume": 100}``` | Changes the audio volume, value 0-100 (i
   * WallPanel subscribes to topic ```wallpanel/[baseTopic]/command```
     * Default Topic: ```wallpanel/mywallpanel/command```
   * Publish a JSON payload to this topic (be mindful of quotes in JSON should be single quotes not double)
+
+## Shell Command
+
+The `shell` command runs a command through the device's shell (`sh -c "<command>"`) and
+is disabled by default. Enable it in **Settings &rarr; HTTP &rarr; Enable Shell Commands
+( Security Risk )** -- you don't need to turn on **REST API** first, even though the
+toggle lives on the same screen. Once enabled, `shell` works over both HTTP and MQTT,
+the same as any other command in the table above -- the setting only lives on the HTTP
+settings screen, it is not HTTP-only.
+
+```json
+{"shell": "log -t WallPanel hello-from-wallpanel"}
+```
+
+Full example using curl:
+
+```sh
+curl --location --request POST 'http://192.168.1.1:2971/api/command' \
+--header 'Content-Type: application/json' \
+--data-raw '{"shell": "log -t WallPanel hello-from-wallpanel"}'
+```
+
+Then confirm it actually ran with `adb logcat | grep WallPanel`.
+
+### It runs unprivileged -- there is no root access, and currently there are no plans to add it
+
+The command runs as a normal child process of the WallPanel app itself, with exactly
+the same permissions the app has been granted and nothing more. There is no `su`, no
+root, no privilege escalation of any kind, and this is deliberate -- it was considered
+and turned down, not just left unbuilt. Even on a device that does have root available,
+WallPanel will not attempt to use it. If you need a shell command that genuinely
+requires root, this feature isn't the way to get it.
+
+This matters because it rules out the commands people most often try first. For
+example, `{"shell": "input keyevent 26"}` (to wake the screen, or send any other key
+event) will never actually do anything: `input keyevent` requires the `INJECT_EVENTS`
+permission, which Android only grants to system apps or apps signed with the platform
+key. A regular installed app -- which is what WallPanel is, even with shell commands
+turned on -- can never hold that permission. The same is true of most commands that
+change system settings, control other apps, or touch hardware directly; if a command
+needs a permission the WallPanel app itself doesn't have, it will fail no matter what
+you put in the payload.
+
+Worth knowing: how visibly this fails depends on the device. On a stock-ish Android 13
+device this shows up clearly in `adb logcat` as a failed command (non-zero exit code)
+with the real reason attached:
+
+```
+Shell command [input keyevent 3] failed with exit code 255, output: Exception occurred while executing 'keyevent':
+java.lang.SecurityException: Injecting input events requires the caller (or the source
+of the instrumentation, if any) to have the INJECT_EVENTS permission.
+```
+
+But on at least one Android 8.1 device we tested, the exact same command exited with
+code `0` and no output at all -- same underlying permission failure, but nothing in the
+log to show for it. Don't take a "succeeded" log line as proof a command like this
+actually had an effect; check for the effect itself (e.g. did the screen actually wake
+up?).
+
+### What actually works
+
+Commands that only need the permissions an ordinary app already has will work fine,
+for example:
+
+- Writing to WallPanel's own private storage, useful for lightweight logging or state
+  from a script:
+
+  ```json
+  {"shell": "echo hello > /data/data/xyz.wallpanel.pro/files/test.txt"}
+  ```
+
+- Reading device or system properties:
+
+  ```json
+  {"shell": "getprop ro.build.version.release"}
+  ```
+
+- Writing to logcat, which you can then watch with `adb logcat`:
+
+  ```json
+  {"shell": "log -t WallPanel hello-from-wallpanel"}
+  ```
+
+- Invoking any other command-line tool present on the device that doesn't itself
+  require elevated permissions.
+
+### Useful examples for a kiosk fleet
+
+These are all real commands verified against real devices, with the actual output they
+produced (via `curl` + `adb logcat`, the same as the ["No success/failure
+feedback"](#no-successfailure-feedback-via-http-or-mqtt) section describes) -- not
+theoretical. If you're managing more than one WallPanel device, this is the kind of
+thing the `shell` command is actually good for: cheap, ad-hoc fleet diagnostics without
+installing a separate MDM tool.
+
+**Which device am I talking to?** Handy when you're scripting against several devices
+and want to confirm you hit the right one:
+
+```json
+{"shell": "getprop ro.product.model"}
+```
+```
+SM-N9005
+```
+
+**Is the device still alive, and has it rebooted recently?** An unexpected uptime reset
+across your fleet is a good sign something is crash-looping:
+
+```json
+{"shell": "uptime"}
+```
+```
+21:58:42 up 3 days, 13:10, 0 users, load average: 10.56, 10.31, 10.46
+```
+
+**How much memory is free?** Useful if a device's browser session has been up for weeks
+and you suspect a leak:
+
+```json
+{"shell": "free -m"}
+```
+```
+             total       used       free     shared    buffers
+Mem:          2834       2683        150         13         56
+-/+ buffers/cache:       2626        207
+Swap:            0          0          0
+```
+
+**How much storage is left?**
+
+```json
+{"shell": "df -h /data"}
+```
+```
+Filesystem     Size  Used Avail Use% Mounted on
+/dev/block/...  11G  0.9G  9.3G  10% /data
+```
+
+**Is the device's network actually working, not just showing a Wi-Fi icon?**
+
+```json
+{"shell": "ping -c 2 8.8.8.8"}
+```
+```
+PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=116 time=12.2 ms
+64 bytes from 8.8.8.8: icmp_seq=2 ttl=116 time=19.2 ms
+
+--- 8.8.8.8 ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1002ms
+```
+
+**Is the device running hot?** Relevant if you've hit the background-CPU issue covered
+in [issue #17](https://github.com/alx-uta/wallpanel-android/issues/17) -- this reads the
+first thermal sensor the kernel exposes:
+
+```json
+{"shell": "cat /sys/class/thermal/thermal_zone0/temp"}
+```
+
+The units aren't consistent across devices -- one of our test devices reported `74000`
+(millidegrees C, i.e. 74°C), another reported `36` (whole degrees C, i.e. 36°C). Sanity
+check what your specific device is giving you before trusting the number.
+
+### Not every read-only command is portable across devices
+
+It's tempting to assume anything that just *reads* something (rather than changing it)
+is safe to rely on everywhere. It isn't -- we hit two examples of this firsthand while
+testing:
+
+- `{"shell": "ip -4 addr show wlan0"}` (reading the device's own IP address) worked
+  cleanly on one test device, but failed on another (a stock-ish Android 13 phone) with
+  `Cannot bind netlink socket: Permission denied`.
+- `{"shell": "cat /sys/class/power_supply/battery/capacity"}` (battery percentage) was
+  readable when run manually via `adb shell`, but denied with `Permission denied` when
+  the exact same file was read by WallPanel itself -- `adb shell` and the app run as
+  different, differently-privileged users, so testing a command with `adb shell` first
+  does not prove WallPanel can run it.
+
+If a command in this guide doesn't work on your device, that's most likely why -- try it
+against your actual hardware before depending on it, the same way we did here.
+
+### Writing to shared storage depends on the Android version
+
+On Android 6 through 9 (API 23-28), turning the shell-command setting on triggers a
+one-time runtime permission prompt for storage access. Granting it lets shell commands
+write to shared storage, e.g. `/sdcard/...`.
+
+On Android 10 and above, this prompt never appears, and there is no way to grant it
+from within the app: Android's scoped-storage rules make that permission ineffective on
+these versions regardless of whether it's granted. On Android 10+, shell commands are
+confined to WallPanel's own private storage (`/data/data/xyz.wallpanel.pro/files/...`)
+as shown above. This is a restriction Android itself places on non-rooted apps, not
+something WallPanel can change.
+
+### No success/failure feedback via HTTP or MQTT
+
+Neither the HTTP response (`{"result": true}` just confirms the request was valid JSON,
+not that the shell command succeeded) nor MQTT gives back any indication of whether a
+shell command succeeded or failed. WallPanel does log every shell command it runs to
+`adb logcat` -- both the exit code and any output the command produced -- so that's the
+place to check when a command doesn't seem to be doing what you expect. As covered
+above, though, a `0` exit code in the log isn't a guarantee the command actually had an
+effect if what it tried to do needed a permission the app doesn't have.
+
+### Treat it as a real attack surface, even without root
+
+"No root" limits the damage a shell command can do, but it doesn't make this safe to
+expose carelessly -- anyone who can reach your MQTT broker or the device's HTTP port can
+run arbitrary commands as the WallPanel app: read anything the app can read, write to
+its private storage, and use the network the device is on. That's exactly why the
+Settings toggle is labeled "Security Risk." Only turn it on if you actually need it, and:
+
+- Don't expose the HTTP port (`2971` by default) to the open internet or an untrusted
+  network -- keep it on a trusted local network only.
+- If you're using MQTT, use broker authentication and, ideally, TLS (see
+  [MQTT Setup](./mqtt-setup.md)) -- anyone who can publish to your command topic can run
+  shell commands the same as anyone who can POST to the HTTP endpoint.
+- Turn it off again when you're done if you only needed it temporarily.
 
 ## Google Text-To-Speech (TTS) Command
 


### PR DESCRIPTION
What's in this PR

### Browser stops draining battery when the screen is off

When GeckoView (the alternate browser engine) is used and the screen turns off, the dashboard can keep using CPU in the background (e.g. from a live WebSocket connection), which drains the battery even though nothing is visible.
This PR adds a new setting, "GeckoView Background Suspend Delay" (default: 30 seconds, 0 to disable), that fully pauses the browser session after the screen has been off for that long.
- The dashboard reloads automatically as soon as the screen turns back on.

### Fixed: screen brightness couldn't be set to the minimum (0)

Previously, trying to set the screen brightness - including the dimmed screensaver brightness - to its lowest possible value was silently ignored because the app only accepted values from 1 upward.
- This is now fixed so a brightness of 0 is accepted.

### Fixed: repeated errors on devices that don't support CPU usage reporting

Some devices block apps from reading CPU usage stats. 
On those devices, the app was retrying and logging an error every few seconds, forever. 
- Now it detects this once and stops retrying, avoiding unnecessary log spam and wasted effort.

### Clearer permission handling for the optional "shell commands" feature
For users who enable the optional remote shell-command feature, the app now properly requests storage permissions on older Android versions (8–9) where they're needed for commands that write to shared storage.
Newer Android versions don't need this and are unaffected. 
- Added documentation explaining how this works.