### PR TITLE
Add Scheduled Tasks, fix app-restart reliability and REST API toggle bugs

### DIFF
--- a/WallPanelPro/build.gradle
+++ b/WallPanelPro/build.gradle
@@ -24,7 +24,7 @@ plugins {
 
 def versionMajor = 1
 def versionMinor = 1
-def versionPatch = 6
+def versionPatch = 7
 def versionBuild = 0 // bump for dog food builds, public betas, etc.
 
 // HA/MQTT test credentials for dev-flavor builds live in local.testconfig.properties
@@ -180,6 +180,7 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
 

--- a/WallPanelPro/src/main/AndroidManifest.xml
+++ b/WallPanelPro/src/main/AndroidManifest.xml
@@ -18,6 +18,13 @@
         tools:ignore="ProtectedPermissions" /> <!-- Optional supported features -->
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
     <!--
+      A restart ends the process, and from API 29 a background application may not start an
+      activity, so the browser is brought back by a full screen intent on a high importance
+      notification. POST_NOTIFICATIONS is requested at runtime on API 33 and above.
+    -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!--
       Only requested when the optional shell command feature is enabled, and only useful on
       API 23-28. From API 29 scoped storage applies (targetSdkVersion 33), so these grant no
       broad file access and are capped with maxSdkVersion.
@@ -109,6 +116,12 @@
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
         </receiver>
+
+        <!-- Only the application's own alarms target this receiver. -->
+        <receiver
+            android:name="xyz.wallpanel.pro.ScheduledTaskReceiver"
+            android:enabled="true"
+            android:exported="false" />
 
         <meta-data
             android:name="com.google.android.gms.vision.DEPENDENCIES"

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/AppExceptionHandler.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/AppExceptionHandler.kt
@@ -17,31 +17,13 @@
 package xyz.wallpanel.pro
 
 import android.app.Activity
-import android.app.AlarmManager
-import android.app.PendingIntent
-import android.content.Context
-import android.content.Intent
-import android.os.Build
-import xyz.wallpanel.pro.ui.activities.BrowserActivityNative
-import kotlin.system.exitProcess
+import timber.log.Timber
+import xyz.wallpanel.pro.utils.AppRestartHelper
 
 class AppExceptionHandler(private val activity: Activity) : Thread.UncaughtExceptionHandler {
     override fun uncaughtException(thread: Thread, ex: Throwable) {
-        val intent = Intent(activity, BrowserActivityNative::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
-                or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                or Intent.FLAG_ACTIVITY_NEW_TASK)
-        
-        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
-        } else {
-            PendingIntent.FLAG_ONE_SHOT
-        }
-        val pendingIntent = PendingIntent.getActivity(activity.applicationContext, 0, intent, flags)
-        
-        val mgr = activity.applicationContext.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        mgr[AlarmManager.RTC, System.currentTimeMillis() + 1000] = pendingIntent
+        Timber.e(ex, "Uncaught exception on thread ${thread.name}, restarting the application")
         activity.finish()
-        exitProcess(2)
+        AppRestartHelper.restartApplication(activity)
     }
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/BootUpReceiver.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/BootUpReceiver.kt
@@ -21,13 +21,23 @@ import android.content.Context
 import android.content.Intent
 import androidx.preference.PreferenceManager
 import xyz.wallpanel.pro.R
+import xyz.wallpanel.pro.persistence.ScheduleRepository
 import xyz.wallpanel.pro.ui.activities.BrowserActivityNative
+import xyz.wallpanel.pro.utils.ScheduledTaskAlarmScheduler
 
 class BootUpReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.action)) {
             val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.applicationContext)
+
+            // AlarmManager drops every alarm on reboot, so the scheduled tasks are armed again
+            // whether or not the application itself opens on boot.
+            ScheduledTaskAlarmScheduler.scheduleAll(
+                context.applicationContext,
+                ScheduleRepository(context.applicationContext, sharedPreferences)
+            )
+
             val startOnBoot = sharedPreferences.getBoolean(context.getString(R.string.key_setting_android_startonboot), false)
             if (startOnBoot) {
                 val i = Intent(context, BrowserActivityNative::class.java)

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ScheduledTaskReceiver.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ScheduledTaskReceiver.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
+import org.json.JSONObject
+import timber.log.Timber
+import xyz.wallpanel.pro.network.WallPanelService
+import xyz.wallpanel.pro.persistence.Configuration
+import xyz.wallpanel.pro.persistence.Schedule
+import xyz.wallpanel.pro.persistence.ScheduleAction
+import xyz.wallpanel.pro.persistence.ScheduleRepository
+import xyz.wallpanel.pro.utils.ScheduledTaskAlarmScheduler
+
+/**
+ * Runs one scheduled task and re-arms its next occurrence. The receiver is created by the
+ * system, so it builds what it needs from the default preferences rather than from Dagger.
+ */
+class ScheduledTaskReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val scheduleId = intent.getStringExtra(ScheduledTaskAlarmScheduler.EXTRA_SCHEDULE_ID)
+        if (scheduleId.isNullOrEmpty()) {
+            Timber.w("Scheduled task alarm arrived without a schedule id")
+            return
+        }
+
+        val applicationContext = context.applicationContext
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        val schedule = ScheduleRepository(applicationContext, sharedPreferences).get(scheduleId)
+        if (schedule == null) {
+            Timber.w("Scheduled task $scheduleId no longer exists, dropping the alarm")
+            return
+        }
+        if (!schedule.enabled) {
+            Timber.i("Scheduled task $scheduleId is disabled, skipping it")
+            return
+        }
+
+        val configuration = Configuration(applicationContext, sharedPreferences)
+        val command = buildCommand(schedule, configuration)
+        if (command != null) {
+            runCommand(applicationContext, command)
+        }
+
+        // Alarms are one shot, so the next occurrence is armed right after this one fires.
+        ScheduledTaskAlarmScheduler.schedule(applicationContext, schedule)
+    }
+
+    private fun buildCommand(schedule: Schedule, configuration: Configuration): JSONObject? {
+        if (schedule.action.requiresPayload() && schedule.payload.isEmpty()) {
+            Timber.w("Scheduled task ${schedule.id} has no payload for ${schedule.action.command}")
+            return null
+        }
+        if (schedule.action == ScheduleAction.SHELL && !configuration.httpShellEnabled) {
+            Timber.w("Scheduled task ${schedule.id} wants a shell command, but shell commands are disabled")
+            return null
+        }
+        val command = JSONObject()
+        when (schedule.action) {
+            ScheduleAction.URL, ScheduleAction.SHELL -> command.put(schedule.action.command, schedule.payload)
+            else -> command.put(schedule.action.command, true)
+        }
+        return command
+    }
+
+    private fun runCommand(context: Context, command: JSONObject) {
+        val intent = Intent(context, WallPanelService::class.java)
+        intent.action = WallPanelService.ACTION_RUN_COMMAND
+        intent.putExtra(WallPanelService.EXTRA_COMMAND_JSON, command.toString())
+        try {
+            ContextCompat.startForegroundService(context, intent)
+            Timber.i("Dispatched scheduled command $command")
+        } catch (e: Exception) {
+            Timber.e(e, "Could not dispatch the scheduled command $command")
+        }
+    }
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/di/AndroidBindingModule.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/di/AndroidBindingModule.kt
@@ -79,4 +79,7 @@ internal abstract class AndroidBindingModule {
 
     @ContributesAndroidInjector
     internal abstract fun sensorsSettings(): SensorsSettingsFragment
+
+    @ContributesAndroidInjector
+    internal abstract fun scheduledTasksSettings(): ScheduledTasksFragment
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
@@ -47,11 +47,13 @@ import timber.log.Timber
 import xyz.wallpanel.pro.R
 import xyz.wallpanel.pro.modules.*
 import xyz.wallpanel.pro.persistence.Configuration
+import xyz.wallpanel.pro.persistence.ScheduleRepository
 import xyz.wallpanel.pro.ui.activities.BaseBrowserActivity.Companion.BROADCAST_ACTION_CLEAR_BROWSER_CACHE
 import xyz.wallpanel.pro.ui.activities.BaseBrowserActivity.Companion.BROADCAST_ACTION_JS_EXEC
 import xyz.wallpanel.pro.ui.activities.BaseBrowserActivity.Companion.BROADCAST_ACTION_LOAD_URL
 import xyz.wallpanel.pro.ui.activities.BaseBrowserActivity.Companion.BROADCAST_ACTION_OPEN_SETTINGS
 import xyz.wallpanel.pro.ui.activities.BaseBrowserActivity.Companion.BROADCAST_ACTION_RELOAD_PAGE
+import xyz.wallpanel.pro.utils.AppRestartHelper
 import xyz.wallpanel.pro.utils.MqttUtils
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_AUDIO
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_BRIGHTNESS
@@ -60,6 +62,7 @@ import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_CLEAR_CACHE
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_EVAL
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_RELAUNCH
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_RELOAD
+import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_RESTART_APP
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_SENSOR
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_SENSOR_FACE
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_SENSOR_MOTION
@@ -74,6 +77,7 @@ import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_WAKE
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.COMMAND_WAKETIME
 import xyz.wallpanel.pro.utils.MqttUtils.Companion.VALUE
 import xyz.wallpanel.pro.utils.NotificationUtils
+import xyz.wallpanel.pro.utils.ScheduledTaskAlarmScheduler
 import xyz.wallpanel.pro.utils.ScreenUtils
 import java.io.IOException
 import java.nio.ByteBuffer
@@ -98,6 +102,9 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
 
     @Inject
     lateinit var screenUtils: ScreenUtils
+
+    @Inject
+    lateinit var scheduleRepository: ScheduleRepository
 
     private val mJpegSockets = ArrayList<AsyncHttpServerResponse>()
     private var cpuWakeLock: PowerManager.WakeLock? = null
@@ -197,6 +204,29 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
         localBroadCastManager?.registerReceiver(mBroadcastReceiver, filter)
 
         registerSystemBroadcastReceiver()
+
+        // Safety net for the alarms: they are dropped on reboot and on a system initiated
+        // clear of the application's data, so they are re-armed whenever the service starts.
+        ScheduledTaskAlarmScheduler.scheduleAll(applicationContext, scheduleRepository)
+    }
+
+    /**
+     * Commands sent from outside the service, currently by the scheduled task receiver,
+     * arrive here as an [ACTION_RUN_COMMAND] intent and go through the same command
+     * handling as MQTT and HTTP.
+     */
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val result = super.onStartCommand(intent, flags, startId)
+        if (intent?.action == ACTION_RUN_COMMAND) {
+            val command = intent.getStringExtra(EXTRA_COMMAND_JSON)
+            if (command.isNullOrEmpty()) {
+                Timber.w("Received a run command intent without a command")
+            } else {
+                Timber.i("Running command from an intent: $command")
+                processCommand(command)
+            }
+        }
+        return result
     }
 
     /**
@@ -492,8 +522,19 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
             Timber.i("Started HTTP server on " + configuration.httpPort)
         }
 
-        if (httpServer != null && configuration.httpRestEnabled) {
+        if (httpServer != null) {
+            // Registered whenever the HTTP server itself is running, but gated on
+            // configuration.httpRestEnabled inside each handler rather than at registration
+            // time: the server is only (re)started from onCreate(), so a route that checked
+            // the flag just once here would keep answering with its startup value for the
+            // life of the process, ignoring the setting being switched off afterward -- the
+            // same live-check approach the shell command already uses for its own toggle.
             httpServer?.addAction("POST", "/api/command") { request, response ->
+                if (!configuration.httpRestEnabled) {
+                    response.code(403)
+                    response.send("REST API is disabled")
+                    return@addAction
+                }
                 var result = false
                 if (request.body is JSONObjectBody) {
                     Timber.i("POST Json Arrived (command)")
@@ -513,10 +554,15 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
             }
 
             httpServer?.addAction("GET", "/api/state") { request, response ->
+                if (!configuration.httpRestEnabled) {
+                    response.code(403)
+                    response.send("REST API is disabled")
+                    return@addAction
+                }
                 Timber.i("GET Arrived (/api/state)")
                 response.send(state)
             }
-            Timber.i("Enabled REST Endpoints")
+            Timber.i("Registered REST endpoints")
         }
 
         if (httpServer != null && configuration.httpMJPEGEnabled) {
@@ -685,12 +731,27 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
             if (commandJson.has(COMMAND_SHELL) && configuration.httpShellEnabled) {
                 executeShellCommand(commandJson.getString(COMMAND_SHELL))
             }
+            // Kept last, it does not return.
+            if (commandJson.has(COMMAND_RESTART_APP)) {
+                if (commandJson.getBoolean(COMMAND_RESTART_APP)) {
+                    restartApplication()
+                }
+            }
         } catch (ex: JSONException) {
             Timber.e("Invalid JSON passed as a command: " + commandJson.toString())
             return false
         }
 
         return true
+    }
+
+    /**
+     * Ends the process and books the browser to come back, the same way the application
+     * recovers from an uncaught exception. Alarms held by the system, including the
+     * scheduled tasks, are unaffected by the process ending.
+     */
+    private fun restartApplication() {
+        AppRestartHelper.restartApplication(applicationContext, RESTART_EXIT_DELAY_MS)
     }
 
     private fun executeShellCommand(command: String) {
@@ -1225,5 +1286,16 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
         const val BROADCAST_CAMERA_START_SCREENSAVER = "BROADCAST_CAMERA_START_SCREENSAVER"
         const val BROADCAST_CAMERA_STOP_SCREENSAVER = "BROADCAST_CAMERA_STOP_SCREENSAVER"
         const val BROADCAST_CONNTED = "BROADCAST_SCREEN_BRIGHTNESS_CHANGE"
+        const val ACTION_RUN_COMMAND = "xyz.wallpanel.pro.action.RUN_COMMAND"
+        const val EXTRA_COMMAND_JSON = "EXTRA_COMMAND_JSON"
+
+        /**
+         * The process exit is delayed rather than immediate: when a restart is reached from
+         * onStartCommand(), a scheduled task, exiting before that call returns kills the
+         * process mid Binder-transaction, which the system reads as an incomplete start and
+         * redelivers the same command to the relaunched process -- observed on-device as
+         * three restarts in a row instead of one. The delay lets onStartCommand() return.
+         */
+        const val RESTART_EXIT_DELAY_MS = 300L
     }
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Configuration.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Configuration.kt
@@ -83,6 +83,12 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
             sharedPreferences.edit().putBoolean(PREF_SHELL_PERMISSIONS, value).apply()
         }
 
+    var notificationPermissionsShown: Boolean
+        get() = sharedPreferences.getBoolean(PREF_NOTIFICATION_PERMISSIONS, false)
+        set(value) {
+            sharedPreferences.edit().putBoolean(PREF_NOTIFICATION_PERMISSIONS, value).apply()
+        }
+
     var cameraRotate: Float
         get() = this.sharedPreferences.getString(PREF_CAMERA_ROTATE, "0f")!!.toFloat()
         set(value) = this.sharedPreferences.edit().putString(PREF_CAMERA_ROTATE, value.toString()).apply()
@@ -450,6 +456,7 @@ constructor(private val context: Context, private val sharedPreferences: SharedP
         const val PREF_WRITE_SCREEN_PERMISSIONS = "pref_write_screen_permissions"
         const val PREF_CAMERA_PERMISSIONS = "pref_camera_permissions"
         const val PREF_SHELL_PERMISSIONS = "pref_shell_permissions"
+        const val PREF_NOTIFICATION_PERMISSIONS = "pref_notification_permissions"
         const val PREF_CAMERA_ROTATE = "pref_camera_rotate"
         const val PREF_BROWSER_REFRESH_DISCONNECT = "pref_browser_refresh_disconnect"
         const val PREF_SCREEN_BRIGHTNESS = "pref_use_screen_brightness"

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Schedule.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/Schedule.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.persistence
+
+import java.util.Calendar
+import java.util.UUID
+
+/**
+ * A user defined task that runs at a time of day on a set of weekdays. [days] holds
+ * [Calendar.DAY_OF_WEEK] values so the trigger maths composes directly with [Calendar].
+ */
+data class Schedule(
+    val id: String = UUID.randomUUID().toString(),
+    val enabled: Boolean = true,
+    val hour: Int,
+    val minute: Int,
+    val days: Set<Int> = ALL_DAYS,
+    val action: ScheduleAction,
+    val payload: String = ""
+) {
+    companion object {
+        val ALL_DAYS: Set<Int> = (Calendar.SUNDAY..Calendar.SATURDAY).toSet()
+    }
+}
+
+/**
+ * The command each schedule dispatches. [command] is the key WallPanelService already
+ * understands, so a schedule reuses the same handling as an MQTT or HTTP command.
+ */
+enum class ScheduleAction(val command: String) {
+    RESTART_APP("restartApp"),
+    RELOAD("reload"),
+    CLEAR_CACHE("clearCache"),
+    RELAUNCH("relaunch"),
+    URL("url"),
+    SHELL("shell");
+
+    /**
+     * True when the action needs the user supplied [Schedule.payload] to mean anything.
+     */
+    fun requiresPayload(): Boolean = this == URL || this == SHELL
+
+    companion object {
+        fun fromCommand(command: String?): ScheduleAction? = values().firstOrNull { it.command == command }
+    }
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/ScheduleRepository.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/ScheduleRepository.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.persistence
+
+import android.content.Context
+import android.content.SharedPreferences
+import xyz.wallpanel.pro.R
+import javax.inject.Inject
+
+/**
+ * Stores the scheduled tasks as one JSON array under a single preference key.
+ */
+class ScheduleRepository @Inject
+constructor(private val context: Context, private val sharedPreferences: SharedPreferences) {
+
+    fun getAll(): List<Schedule> {
+        val stored = sharedPreferences.getString(scheduleKey(), "").orEmpty()
+        return ScheduleSerializer.fromJsonArray(stored)
+    }
+
+    fun getEnabled(): List<Schedule> = getAll().filter { it.enabled }
+
+    fun get(id: String): Schedule? = getAll().firstOrNull { it.id == id }
+
+    /**
+     * Replaces the schedule carrying the same id, or appends it when the id is new.
+     */
+    fun save(schedule: Schedule) {
+        val schedules = getAll().toMutableList()
+        val index = schedules.indexOfFirst { it.id == schedule.id }
+        if (index >= 0) {
+            schedules[index] = schedule
+        } else {
+            schedules.add(schedule)
+        }
+        write(schedules)
+    }
+
+    fun delete(id: String) {
+        write(getAll().filterNot { it.id == id })
+    }
+
+    private fun write(schedules: List<Schedule>) {
+        sharedPreferences.edit()
+            .putString(scheduleKey(), ScheduleSerializer.toJsonArray(schedules))
+            .apply()
+    }
+
+    private fun scheduleKey(): String = context.getString(R.string.key_setting_schedules)
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/ScheduleSerializer.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/persistence/ScheduleSerializer.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.persistence
+
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+import java.util.UUID
+
+/**
+ * Encodes the schedule list as a single JSON array so it fits in one preference value.
+ * Decoding drops entries it cannot understand and keeps the rest, so one bad or
+ * newer-than-this-build entry never takes the whole list with it.
+ */
+object ScheduleSerializer {
+
+    private const val KEY_ID = "id"
+    private const val KEY_ENABLED = "enabled"
+    private const val KEY_HOUR = "hour"
+    private const val KEY_MINUTE = "minute"
+    private const val KEY_DAYS = "days"
+    private const val KEY_ACTION = "action"
+    private const val KEY_PAYLOAD = "payload"
+
+    fun toJsonArray(schedules: List<Schedule>): String {
+        val array = JSONArray()
+        for (schedule in schedules) {
+            val days = JSONArray()
+            for (day in schedule.days.sorted()) {
+                days.put(day)
+            }
+            val json = JSONObject()
+            json.put(KEY_ID, schedule.id)
+            json.put(KEY_ENABLED, schedule.enabled)
+            json.put(KEY_HOUR, schedule.hour)
+            json.put(KEY_MINUTE, schedule.minute)
+            json.put(KEY_DAYS, days)
+            json.put(KEY_ACTION, schedule.action.command)
+            json.put(KEY_PAYLOAD, schedule.payload)
+            array.put(json)
+        }
+        return array.toString()
+    }
+
+    fun fromJsonArray(json: String): List<Schedule> {
+        if (json.isEmpty()) {
+            return emptyList()
+        }
+        val schedules = ArrayList<Schedule>()
+        try {
+            val array = JSONArray(json)
+            for (i in 0 until array.length()) {
+                val entry = array.optJSONObject(i)
+                if (entry == null) {
+                    Timber.w("Skipping schedule entry at index $i, it is not an object")
+                    continue
+                }
+                val action = ScheduleAction.fromCommand(entry.optString(KEY_ACTION))
+                if (action == null) {
+                    Timber.w("Skipping schedule with unknown action ${entry.optString(KEY_ACTION)}")
+                    continue
+                }
+                schedules.add(
+                    Schedule(
+                        id = entry.optString(KEY_ID, "").ifEmpty { UUID.randomUUID().toString() },
+                        enabled = entry.optBoolean(KEY_ENABLED, true),
+                        hour = entry.optInt(KEY_HOUR, 0),
+                        minute = entry.optInt(KEY_MINUTE, 0),
+                        days = readDays(entry),
+                        action = action,
+                        payload = entry.optString(KEY_PAYLOAD, "")
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Could not read the stored schedules, starting from an empty list")
+            return emptyList()
+        }
+        return schedules
+    }
+
+    /**
+     * An absent day list means the schedule predates the field or was written by hand, and
+     * every day is the sensible reading. An empty list is a deliberate choice and stays empty.
+     */
+    private fun readDays(entry: JSONObject): Set<Int> {
+        val days = entry.optJSONArray(KEY_DAYS) ?: return Schedule.ALL_DAYS
+        val values = LinkedHashSet<Int>()
+        for (i in 0 until days.length()) {
+            values.add(days.optInt(i))
+        }
+        return values
+    }
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BrowserActivityNative.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/activities/BrowserActivityNative.kt
@@ -16,6 +16,7 @@
 
 package xyz.wallpanel.pro.ui.activities
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -38,6 +39,7 @@ import androidx.lifecycle.LifecycleObserver
 import xyz.wallpanel.pro.databinding.ActivityBrowserBinding
 import xyz.wallpanel.pro.network.ConnectionLiveData
 import xyz.wallpanel.pro.ui.fragments.CodeBottomSheetFragment
+import xyz.wallpanel.pro.utils.AppRestartHelper
 import xyz.wallpanel.pro.utils.InternalWebChromeClient
 import xyz.wallpanel.pro.ui.views.WebClientCallback
 import xyz.wallpanel.pro.utils.InternalWebClient
@@ -149,6 +151,55 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
         configureConnection()
         configureWebView(binding.root)
         initWebPageLoad()
+        requestNotificationPermissions()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // The browser is back, so the notification offering to reopen it has served its purpose
+        AppRestartHelper.cancelRestartNotification(this)
+    }
+
+    /**
+     * A restart posts a notification to bring the browser back, which on API 33 and above is
+     * silently dropped without this permission. It is asked for once, and the application
+     * carries on either way.
+     */
+    private fun requestNotificationPermissions() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || configuration.notificationPermissionsShown) {
+            return
+        }
+        configuration.notificationPermissionsShown = true
+        if (PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            )
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                PERMISSIONS_REQUEST_NOTIFICATIONS
+            )
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == PERMISSIONS_REQUEST_NOTIFICATIONS) {
+            // If request is cancelled, the result arrays are empty.
+            if (grantResults.isEmpty() || grantResults.any { it != PackageManager.PERMISSION_GRANTED }) {
+                Timber.d("Notification permission was not granted")
+                Toast.makeText(
+                    this,
+                    R.string.toast_notification_permission_denied,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
     }
 
     override fun onStart() {
@@ -703,4 +754,7 @@ class BrowserActivityNative : BaseBrowserActivity(), LifecycleObserver, WebClien
         }
     }
 
+    companion object {
+        const val PERMISSIONS_REQUEST_NOTIFICATIONS = 220
+    }
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/adapters/ScheduleAdapter.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/adapters/ScheduleAdapter.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.ui.adapters
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import xyz.wallpanel.pro.R
+import xyz.wallpanel.pro.databinding.ItemScheduleBinding
+import xyz.wallpanel.pro.persistence.Schedule
+import java.util.Calendar
+
+/**
+ * Lists the scheduled tasks. A row shows the time, a readable summary of the days and the
+ * action, an enabled switch and a delete button.
+ */
+class ScheduleAdapter(
+    private val onEdit: (Schedule) -> Unit,
+    private val onToggle: (Schedule, Boolean) -> Unit,
+    private val onDelete: (Schedule) -> Unit
+) : RecyclerView.Adapter<ScheduleAdapter.ViewHolder>() {
+
+    private var schedules: List<Schedule> = emptyList()
+
+    // The list is short and only changes when the user adds, edits or deletes a task, so a
+    // full rebind is cheaper than tracking item level changes.
+    @SuppressLint("NotifyDataSetChanged")
+    fun setSchedules(schedules: List<Schedule>) {
+        this.schedules = schedules
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemScheduleBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(schedules[position])
+    }
+
+    override fun getItemCount(): Int = schedules.size
+
+    inner class ViewHolder(private val binding: ItemScheduleBinding) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(schedule: Schedule) {
+            val context = binding.root.context
+            binding.scheduleTime.text = formatTime(context, schedule)
+            binding.scheduleSummary.text = formatSummary(context, schedule)
+
+            // Cleared first so rebinding a recycled row does not report a change the user
+            // never made.
+            binding.scheduleEnabled.setOnCheckedChangeListener(null)
+            binding.scheduleEnabled.isChecked = schedule.enabled
+            binding.scheduleEnabled.setOnCheckedChangeListener { _, isChecked ->
+                onToggle(schedule, isChecked)
+            }
+
+            binding.scheduleRow.setOnClickListener { onEdit(schedule) }
+            binding.scheduleDelete.setOnClickListener { onDelete(schedule) }
+        }
+    }
+
+    companion object {
+
+        fun formatTime(context: Context, schedule: Schedule): String =
+            context.getString(R.string.schedule_time_format, schedule.hour, schedule.minute)
+
+        /**
+         * For example "Every day · Restart Application" or "Mon, Fri · Reload Page".
+         */
+        fun formatSummary(context: Context, schedule: Schedule): String {
+            val separator = context.getString(R.string.schedule_summary_separator)
+            val actionNames = context.resources.getStringArray(R.array.schedule_action_names)
+            val parts = ArrayList<String>()
+            parts.add(formatDays(context, schedule.days))
+            parts.add(actionNames.getOrElse(schedule.action.ordinal) { schedule.action.command })
+            if (schedule.payload.isNotEmpty()) {
+                parts.add(schedule.payload)
+            }
+            if (!schedule.enabled) {
+                parts.add(context.getString(R.string.schedule_summary_disabled))
+            }
+            return parts.joinToString(separator)
+        }
+
+        fun formatDays(context: Context, days: Set<Int>): String {
+            if (days.containsAll(Schedule.ALL_DAYS)) {
+                return context.getString(R.string.schedule_summary_every_day)
+            }
+            val dayNames = context.resources.getStringArray(R.array.schedule_day_names_short)
+            return (Calendar.SUNDAY..Calendar.SATURDAY)
+                .filter { day -> days.contains(day) }
+                .joinToString(", ") { day -> dayNames.getOrElse(day - 1) { "" } }
+        }
+    }
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/dialogs/ScheduleEditDialogFragment.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/dialogs/ScheduleEditDialogFragment.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.ui.dialogs
+
+import android.app.Dialog
+import android.app.TimePickerDialog
+import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.Toast
+import android.widget.ToggleButton
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import xyz.wallpanel.pro.R
+import xyz.wallpanel.pro.databinding.DialogEditScheduleBinding
+import xyz.wallpanel.pro.persistence.Schedule
+import xyz.wallpanel.pro.persistence.ScheduleAction
+import xyz.wallpanel.pro.utils.DateUtils
+import java.util.Calendar
+
+/**
+ * Add and edit form for one scheduled task. The dialog owns no storage: it hands the result
+ * back to the hosting fragment through the fragment result API, and that fragment writes it.
+ */
+class ScheduleEditDialogFragment : DialogFragment() {
+
+    private lateinit var binding: DialogEditScheduleBinding
+
+    private var hour: Int = 7
+    private var minute: Int = 0
+    private val days: MutableSet<Int> = HashSet()
+
+    private val dayToggles: List<ToggleButton> by lazy {
+        listOf(
+            binding.scheduleDay0,
+            binding.scheduleDay1,
+            binding.scheduleDay2,
+            binding.scheduleDay3,
+            binding.scheduleDay4,
+            binding.scheduleDay5,
+            binding.scheduleDay6
+        )
+    }
+
+    private val scheduleId: String? get() = arguments?.getString(ARG_ID)
+    private val isEdit: Boolean get() = scheduleId != null
+    private val shellEnabled: Boolean get() = arguments?.getBoolean(ARG_SHELL_ENABLED, false) ?: false
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        binding = DialogEditScheduleBinding.inflate(layoutInflater)
+
+        restoreState(savedInstanceState)
+        bindDayToggles()
+        bindTimeButton()
+        bindActionSpinner()
+        binding.scheduleEnabledSwitch.isChecked = arguments?.getBoolean(ARG_ENABLED, true) ?: true
+
+        val builder = AlertDialog.Builder(requireContext())
+            .setTitle(if (isEdit) R.string.dialog_title_edit_schedule else R.string.dialog_title_add_schedule)
+            .setView(binding.root)
+            .setPositiveButton(R.string.button_save, null)
+            .setNegativeButton(R.string.button_cancel, null)
+        if (isEdit) {
+            builder.setNeutralButton(R.string.button_delete, null)
+        }
+        return builder.create()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // The buttons are wired here so a failed validation can keep the dialog open.
+        val dialog = dialog as? AlertDialog ?: return
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE)?.setOnClickListener { save() }
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL)?.setOnClickListener { delete() }
+        dialog.getButton(AlertDialog.BUTTON_NEGATIVE)?.setOnClickListener { dismiss() }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(STATE_HOUR, hour)
+        outState.putInt(STATE_MINUTE, minute)
+        outState.putIntArray(STATE_DAYS, days.toIntArray())
+    }
+
+    private fun restoreState(savedInstanceState: Bundle?) {
+        days.clear()
+        if (savedInstanceState != null) {
+            hour = savedInstanceState.getInt(STATE_HOUR, 7)
+            minute = savedInstanceState.getInt(STATE_MINUTE, 0)
+            days.addAll(savedInstanceState.getIntArray(STATE_DAYS)?.toList() ?: Schedule.ALL_DAYS)
+            return
+        }
+        val arguments = arguments
+        hour = arguments?.getInt(ARG_HOUR, 7) ?: 7
+        minute = arguments?.getInt(ARG_MINUTE, 0) ?: 0
+        days.addAll(arguments?.getIntArray(ARG_DAYS)?.toList() ?: Schedule.ALL_DAYS)
+    }
+
+    private fun bindTimeButton() {
+        showTime()
+        binding.scheduleTimeButton.setOnClickListener {
+            TimePickerDialog(
+                requireContext(),
+                { _, pickedHour, pickedMinute ->
+                    // Routed through DateUtils so the time picker output is parsed the same
+                    // way everywhere in the application.
+                    val picked = "${DateUtils.padTimePickerOutput(pickedHour.toString())}:${DateUtils.padTimePickerOutput(pickedMinute.toString())}"
+                    hour = DateUtils.getHourFromTimePicker(picked)
+                    minute = DateUtils.getMinutesFromTimePicker(picked)
+                    showTime()
+                },
+                hour,
+                minute,
+                true
+            ).show()
+        }
+    }
+
+    private fun showTime() {
+        binding.scheduleTimeButton.text = getString(R.string.schedule_time_format, hour, minute)
+    }
+
+    private fun bindDayToggles() {
+        val dayNames = resources.getStringArray(R.array.schedule_day_names_short)
+        dayToggles.forEachIndexed { index, toggle ->
+            val day = Calendar.SUNDAY + index
+            val name = dayNames.getOrElse(index) { "" }
+            toggle.textOn = name
+            toggle.textOff = name
+            toggle.text = name
+            toggle.isChecked = days.contains(day)
+            toggle.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) days.add(day) else days.remove(day)
+            }
+        }
+    }
+
+    private fun bindActionSpinner() {
+        val selected = arguments?.getString(ARG_ACTION)?.let { ScheduleAction.fromCommand(it) }
+            ?: ScheduleAction.RESTART_APP
+        binding.scheduleActionSpinner.setSelection(selected.ordinal)
+        binding.schedulePayload.setText(arguments?.getString(ARG_PAYLOAD).orEmpty())
+        showPayloadFor(selected)
+        binding.scheduleActionSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                showPayloadFor(selectedAction())
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) {}
+        }
+    }
+
+    private fun selectedAction(): ScheduleAction =
+        ScheduleAction.values().getOrElse(binding.scheduleActionSpinner.selectedItemPosition) { ScheduleAction.RESTART_APP }
+
+    private fun showPayloadFor(action: ScheduleAction) {
+        binding.schedulePayload.visibility = if (action.requiresPayload()) View.VISIBLE else View.GONE
+        binding.schedulePayload.hint = when (action) {
+            ScheduleAction.URL -> getString(R.string.schedule_hint_url)
+            ScheduleAction.SHELL -> getString(R.string.schedule_hint_shell)
+            else -> ""
+        }
+        binding.scheduleShellWarning.visibility =
+            if (action == ScheduleAction.SHELL && !shellEnabled) View.VISIBLE else View.GONE
+    }
+
+    private fun save() {
+        if (days.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.toast_schedule_no_days, Toast.LENGTH_SHORT).show()
+            return
+        }
+        val action = selectedAction()
+        val payload = binding.schedulePayload.text.toString().trim()
+        if (action.requiresPayload() && payload.isEmpty()) {
+            Toast.makeText(requireContext(), R.string.toast_schedule_payload_required, Toast.LENGTH_SHORT).show()
+            return
+        }
+        val result = Bundle()
+        result.putString(RESULT_OPERATION, OPERATION_SAVE)
+        result.putString(RESULT_ID, scheduleId)
+        result.putBoolean(RESULT_ENABLED, binding.scheduleEnabledSwitch.isChecked)
+        result.putInt(RESULT_HOUR, hour)
+        result.putInt(RESULT_MINUTE, minute)
+        result.putIntArray(RESULT_DAYS, days.toIntArray())
+        result.putString(RESULT_ACTION, action.command)
+        result.putString(RESULT_PAYLOAD, payload)
+        parentFragmentManager.setFragmentResult(REQUEST_KEY, result)
+        dismiss()
+    }
+
+    private fun delete() {
+        val result = Bundle()
+        result.putString(RESULT_OPERATION, OPERATION_DELETE)
+        result.putString(RESULT_ID, scheduleId)
+        parentFragmentManager.setFragmentResult(REQUEST_KEY, result)
+        dismiss()
+    }
+
+    companion object {
+        const val TAG = "ScheduleEditDialogFragment"
+        const val REQUEST_KEY = "schedule_edit_request"
+
+        const val RESULT_OPERATION = "operation"
+        const val RESULT_ID = "id"
+        const val RESULT_ENABLED = "enabled"
+        const val RESULT_HOUR = "hour"
+        const val RESULT_MINUTE = "minute"
+        const val RESULT_DAYS = "days"
+        const val RESULT_ACTION = "action"
+        const val RESULT_PAYLOAD = "payload"
+
+        const val OPERATION_SAVE = "save"
+        const val OPERATION_DELETE = "delete"
+
+        private const val ARG_ID = "arg_id"
+        private const val ARG_ENABLED = "arg_enabled"
+        private const val ARG_HOUR = "arg_hour"
+        private const val ARG_MINUTE = "arg_minute"
+        private const val ARG_DAYS = "arg_days"
+        private const val ARG_ACTION = "arg_action"
+        private const val ARG_PAYLOAD = "arg_payload"
+        private const val ARG_SHELL_ENABLED = "arg_shell_enabled"
+
+        private const val STATE_HOUR = "state_hour"
+        private const val STATE_MINUTE = "state_minute"
+        private const val STATE_DAYS = "state_days"
+
+        fun newInstance(schedule: Schedule?, shellEnabled: Boolean): ScheduleEditDialogFragment {
+            val arguments = Bundle()
+            arguments.putBoolean(ARG_SHELL_ENABLED, shellEnabled)
+            if (schedule != null) {
+                arguments.putString(ARG_ID, schedule.id)
+                arguments.putBoolean(ARG_ENABLED, schedule.enabled)
+                arguments.putInt(ARG_HOUR, schedule.hour)
+                arguments.putInt(ARG_MINUTE, schedule.minute)
+                arguments.putIntArray(ARG_DAYS, schedule.days.toIntArray())
+                arguments.putString(ARG_ACTION, schedule.action.command)
+                arguments.putString(ARG_PAYLOAD, schedule.payload)
+            }
+            val fragment = ScheduleEditDialogFragment()
+            fragment.arguments = arguments
+            return fragment
+        }
+    }
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/ScheduledTasksFragment.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/ScheduledTasksFragment.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.ui.fragments
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.navigation.Navigation
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import dagger.android.support.AndroidSupportInjection
+import xyz.wallpanel.pro.R
+import xyz.wallpanel.pro.databinding.FragmentScheduledTasksBinding
+import xyz.wallpanel.pro.persistence.Configuration
+import xyz.wallpanel.pro.persistence.Schedule
+import xyz.wallpanel.pro.persistence.ScheduleAction
+import xyz.wallpanel.pro.persistence.ScheduleRepository
+import xyz.wallpanel.pro.ui.activities.SettingsActivity
+import xyz.wallpanel.pro.ui.adapters.ScheduleAdapter
+import xyz.wallpanel.pro.ui.dialogs.ScheduleEditDialogFragment
+import xyz.wallpanel.pro.utils.ScheduledTaskAlarmScheduler
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Lists the scheduled tasks and hosts the add and edit dialog. This is a plain fragment
+ * rather than a preference screen, a preference screen cannot show a list the user adds to
+ * and removes from.
+ */
+class ScheduledTasksFragment : Fragment() {
+
+    @Inject
+    lateinit var configuration: Configuration
+
+    @Inject
+    lateinit var scheduleRepository: ScheduleRepository
+
+    private var binding: FragmentScheduledTasksBinding? = null
+
+    private val adapter: ScheduleAdapter by lazy {
+        ScheduleAdapter(
+            onEdit = { schedule -> showEditDialog(schedule) },
+            onToggle = { schedule, enabled -> saveSchedule(schedule.copy(enabled = enabled), notify = false) },
+            onDelete = { schedule -> deleteSchedule(schedule.id) }
+        )
+    }
+
+    override fun onAttach(context: Context) {
+        AndroidSupportInjection.inject(this)
+        super.onAttach(context)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        childFragmentManager.setFragmentResultListener(
+            ScheduleEditDialogFragment.REQUEST_KEY,
+            this
+        ) { _, result -> handleDialogResult(result) }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        val binding = FragmentScheduledTasksBinding.inflate(inflater, container, false)
+        this.binding = binding
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (activity is SettingsActivity) {
+            val actionBar = (activity as SettingsActivity).supportActionBar
+            with(actionBar) {
+                this?.setDisplayHomeAsUpEnabled(true)
+                this?.setDisplayShowHomeEnabled(true)
+                this?.title = getString(R.string.title_scheduled_tasks)
+            }
+        }
+
+        binding?.scheduleList?.let { list ->
+            list.layoutManager = LinearLayoutManager(requireContext())
+            list.addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
+            list.adapter = adapter
+        }
+
+        showSchedules()
+    }
+
+    override fun onDestroyView() {
+        // The adapter holds the item views, so it is detached before the binding goes away.
+        binding?.scheduleList?.adapter = null
+        binding = null
+        super.onDestroyView()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_scheduled_tasks, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> {
+                view?.let { Navigation.findNavController(it).navigate(R.id.settings_action) }
+                return true
+            }
+            R.id.action_add_schedule -> {
+                showEditDialog(null)
+                return true
+            }
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    private fun showEditDialog(schedule: Schedule?) {
+        if (childFragmentManager.findFragmentByTag(ScheduleEditDialogFragment.TAG) != null) {
+            return
+        }
+        ScheduleEditDialogFragment.newInstance(schedule, configuration.httpShellEnabled)
+            .show(childFragmentManager, ScheduleEditDialogFragment.TAG)
+    }
+
+    private fun handleDialogResult(result: Bundle) {
+        when (result.getString(ScheduleEditDialogFragment.RESULT_OPERATION)) {
+            ScheduleEditDialogFragment.OPERATION_DELETE -> {
+                result.getString(ScheduleEditDialogFragment.RESULT_ID)?.let { deleteSchedule(it) }
+            }
+            ScheduleEditDialogFragment.OPERATION_SAVE -> {
+                val action = ScheduleAction.fromCommand(result.getString(ScheduleEditDialogFragment.RESULT_ACTION))
+                if (action == null) {
+                    return
+                }
+                val id = result.getString(ScheduleEditDialogFragment.RESULT_ID)
+                val days = result.getIntArray(ScheduleEditDialogFragment.RESULT_DAYS)?.toSet().orEmpty()
+                val schedule = Schedule(
+                    id = id ?: UUID.randomUUID().toString(),
+                    enabled = result.getBoolean(ScheduleEditDialogFragment.RESULT_ENABLED, true),
+                    hour = result.getInt(ScheduleEditDialogFragment.RESULT_HOUR, 0),
+                    minute = result.getInt(ScheduleEditDialogFragment.RESULT_MINUTE, 0),
+                    days = days,
+                    action = action,
+                    payload = result.getString(ScheduleEditDialogFragment.RESULT_PAYLOAD).orEmpty()
+                )
+                saveSchedule(schedule, notify = true)
+            }
+        }
+    }
+
+    private fun saveSchedule(schedule: Schedule, notify: Boolean) {
+        scheduleRepository.save(schedule)
+        if (schedule.enabled) {
+            ScheduledTaskAlarmScheduler.schedule(requireContext(), schedule)
+        } else {
+            ScheduledTaskAlarmScheduler.cancel(requireContext(), schedule.id)
+        }
+        showSchedules()
+        if (notify) {
+            Toast.makeText(requireContext(), R.string.toast_schedule_saved, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun deleteSchedule(id: String) {
+        scheduleRepository.delete(id)
+        ScheduledTaskAlarmScheduler.cancel(requireContext(), id)
+        showSchedules()
+        Toast.makeText(requireContext(), R.string.toast_schedule_deleted, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun showSchedules() {
+        val schedules = scheduleRepository.getAll()
+        adapter.setSchedules(schedules)
+        binding?.scheduleEmptyText?.visibility = if (schedules.isEmpty()) View.VISIBLE else View.GONE
+    }
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/ScheduledTasksFragment.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/ScheduledTasksFragment.kt
@@ -104,6 +104,8 @@ class ScheduledTasksFragment : Fragment() {
             list.adapter = adapter
         }
 
+        binding?.addScheduleFab?.setOnClickListener { showEditDialog(null) }
+
         showSchedules()
     }
 

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/SettingsFragment.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/ui/fragments/SettingsFragment.kt
@@ -73,6 +73,7 @@ class SettingsFragment : BaseSettingsFragment() {
     private var mqttPreference: Preference? = null
     private var httpPreference: Preference? = null
     private var sensorsPreference: Preference? = null
+    private var scheduledTasksPreference: Preference? = null
     private var aboutPreference: Preference? = null
     private var brightnessPreference: Preference? = null
     private var clearCachePreference: Preference? = null
@@ -251,6 +252,7 @@ class SettingsFragment : BaseSettingsFragment() {
         mqttPreference = findPreference("button_key_mqtt")
         httpPreference = findPreference("button_key_http")
         sensorsPreference = findPreference("button_key_sensors")
+        scheduledTasksPreference = findPreference("button_key_scheduled_tasks")
         aboutPreference = findPreference("button_key_about")
         brightnessPreference = findPreference("button_key_brightness")
         clearCachePreference = findPreference("button_clear_cache")
@@ -296,6 +298,10 @@ class SettingsFragment : BaseSettingsFragment() {
             }
             sensorsPreference?.onPreferenceClickListener = Preference.OnPreferenceClickListener { preference ->
                 view.let { Navigation.findNavController(it).navigate(R.id.sensors_action) }
+                false
+            }
+            scheduledTasksPreference?.onPreferenceClickListener = Preference.OnPreferenceClickListener { preference ->
+                view.let { Navigation.findNavController(it).navigate(R.id.scheduled_tasks_action) }
                 false
             }
             codePreference.onPreferenceClickListener = Preference.OnPreferenceClickListener {

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/AppRestartHelper.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/AppRestartHelper.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.utils
+
+import android.Manifest
+import android.app.AlarmManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import timber.log.Timber
+import xyz.wallpanel.pro.R
+import xyz.wallpanel.pro.ui.activities.BrowserActivityNative
+import kotlin.system.exitProcess
+
+/**
+ * Restarts the application: the browser is booked to come back, then the process ends.
+ *
+ * From Android 10 an application in the background may not start an activity, so the alarm
+ * that used to bring the browser back is rejected with "Abort background activity starts"
+ * and the device is left on the launcher. A full screen intent on a high importance
+ * notification is the supported way to show an activity from the background, the same
+ * mechanism alarm clocks and incoming calls use, so the relaunch is posted that way and the
+ * alarm is kept as a second, cheaper attempt that still works when the application is in
+ * the foreground.
+ */
+object AppRestartHelper {
+
+    const val RESTART_CHANNEL_ID = "xyz.wallpanel.pro.RESTART"
+    const val RESTART_NOTIFICATION_ID = 1139
+
+    private const val RELAUNCH_REQUEST_CODE = 1139
+    private const val ALARM_DELAY_MS = 1000L
+
+    /**
+     * Books the relaunch and ends the process.
+     *
+     * @param exitDelayMillis how long to wait before ending the process. Callers reached from
+     * a Binder transaction, such as Service.onStartCommand(), need a short delay: exiting
+     * before that call returns reads to the system as an incomplete start and redelivers the
+     * same command to the relaunched process, observed on-device as three restarts in a row
+     * instead of one. Zero exits immediately, which is what a crash handler needs, since the
+     * main looper may no longer run anything that is posted to it.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun restartApplication(context: Context, exitDelayMillis: Long = 0L) {
+        Timber.i("Restarting the application")
+        val appContext = context.applicationContext
+        val pendingIntent = createRelaunchPendingIntent(appContext)
+        postRestartNotification(appContext, pendingIntent)
+        scheduleRelaunchAlarm(appContext, pendingIntent)
+        if (exitDelayMillis > 0) {
+            Handler(Looper.getMainLooper()).postDelayed({ exitProcess(2) }, exitDelayMillis)
+        } else {
+            exitProcess(2)
+        }
+    }
+
+    /**
+     * Clears the relaunch notification, which is left in place on purpose so it can be tapped
+     * when the full screen intent does not open the browser on its own.
+     */
+    @JvmStatic
+    fun cancelRestartNotification(context: Context) {
+        try {
+            NotificationManagerCompat.from(context.applicationContext)
+                    .cancel(RESTART_NOTIFICATION_ID)
+        } catch (e: Exception) {
+            Timber.e(e, "Unable to cancel the restart notification")
+        }
+    }
+
+    private fun createRelaunchPendingIntent(context: Context): PendingIntent {
+        val intent = Intent(context, BrowserActivityNative::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
+                or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                or Intent.FLAG_ACTIVITY_NEW_TASK)
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        return PendingIntent.getActivity(context, RELAUNCH_REQUEST_CODE, intent, flags)
+    }
+
+    private fun postRestartNotification(context: Context, pendingIntent: PendingIntent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+            if (granted != PackageManager.PERMISSION_GRANTED) {
+                // The alarm is then the only attempt left, and the restart must still happen.
+                Timber.w("No notification permission, the restart notification is not posted")
+                return
+            }
+        }
+        try {
+            createRestartChannel(context)
+            val notification = NotificationCompat.Builder(context, RESTART_CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_stat_name)
+                    .setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+                    .setContentTitle(context.getString(R.string.text_restart_notification_title))
+                    .setContentText(context.getString(R.string.text_restart_notification_message))
+                    .setColor(ContextCompat.getColor(context, R.color.colorPrimary))
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setCategory(NotificationCompat.CATEGORY_ALARM)
+                    .setLocalOnly(true)
+                    .setOngoing(true)
+                    .setAutoCancel(false)
+                    .setContentIntent(pendingIntent)
+                    .setFullScreenIntent(pendingIntent, true)
+                    .build()
+            NotificationManagerCompat.from(context).notify(RESTART_NOTIFICATION_ID, notification)
+        } catch (e: Exception) {
+            Timber.e(e, "Unable to post the restart notification")
+        }
+    }
+
+    private fun createRestartChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+                ?: return
+        val channel = NotificationChannel(
+                RESTART_CHANNEL_ID,
+                context.getString(R.string.text_restart_channel_name),
+                NotificationManager.IMPORTANCE_HIGH)
+        channel.description = context.getString(R.string.text_restart_channel_description)
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun scheduleRelaunchAlarm(context: Context, pendingIntent: PendingIntent) {
+        try {
+            val manager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+            manager[AlarmManager.RTC, System.currentTimeMillis() + ALARM_DELAY_MS] = pendingIntent
+        } catch (e: Exception) {
+            Timber.e(e, "Unable to schedule the relaunch alarm")
+        }
+    }
+}

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/MqttUtils.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/MqttUtils.kt
@@ -52,6 +52,7 @@ class MqttUtils {
         const val COMMAND_SPEAK = "speak"
         const val COMMAND_VOLUME = "volume"
         const val COMMAND_SHELL = "shell"
+        const val COMMAND_RESTART_APP = "restartApp"
 
         private val topicsList = ArrayList<String>()
 

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/ScheduledTaskAlarmScheduler.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/utils/ScheduledTaskAlarmScheduler.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.utils
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import timber.log.Timber
+import xyz.wallpanel.pro.ScheduledTaskReceiver
+import xyz.wallpanel.pro.persistence.Schedule
+import xyz.wallpanel.pro.persistence.ScheduleRepository
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * Arms one AlarmManager alarm per enabled schedule. Alarms are inexact
+ * ([AlarmManager.setAndAllowWhileIdle]): they survive Doze but need no
+ * SCHEDULE_EXACT_ALARM grant, and firing a few minutes late is fine for restart, reload
+ * and URL switching.
+ *
+ * Alarms are dropped by the system on reboot, so BootUpReceiver re-arms them, and
+ * WallPanelService does the same on start as a safety net.
+ */
+object ScheduledTaskAlarmScheduler {
+
+    const val EXTRA_SCHEDULE_ID = "scheduleId"
+
+    /**
+     * The next instant this schedule should fire, or null when it never will. An instant
+     * exactly equal to [nowMillis] counts as already passed, so the receiver re-arming
+     * itself right after firing cannot land on the same instant twice.
+     */
+    fun nextTriggerMillis(
+        schedule: Schedule,
+        nowMillis: Long,
+        zone: TimeZone = TimeZone.getDefault()
+    ): Long? {
+        if (!schedule.enabled || schedule.days.isEmpty()) {
+            return null
+        }
+        // Today plus a full week, so a schedule whose only day is today but whose time has
+        // passed lands on the same weekday next week.
+        for (offset in 0..7) {
+            val candidate = Calendar.getInstance(zone)
+            candidate.timeInMillis = nowMillis
+            candidate.add(Calendar.DAY_OF_YEAR, offset)
+            candidate.set(Calendar.HOUR_OF_DAY, schedule.hour)
+            candidate.set(Calendar.MINUTE, schedule.minute)
+            candidate.set(Calendar.SECOND, 0)
+            candidate.set(Calendar.MILLISECOND, 0)
+            if (schedule.days.contains(candidate.get(Calendar.DAY_OF_WEEK)) && candidate.timeInMillis > nowMillis) {
+                return candidate.timeInMillis
+            }
+        }
+        return null
+    }
+
+    fun schedule(context: Context, schedule: Schedule) {
+        val triggerMillis = nextTriggerMillis(schedule, System.currentTimeMillis())
+        if (triggerMillis == null) {
+            cancel(context, schedule.id)
+            return
+        }
+        val alarmManager = alarmManager(context) ?: return
+        val pendingIntent = pendingIntent(context, schedule.id)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerMillis, pendingIntent)
+            } else {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, triggerMillis, pendingIntent)
+            }
+            Timber.d("Scheduled task ${schedule.id} (${schedule.action.command}) for ${Calendar.getInstance().apply { timeInMillis = triggerMillis }.time}")
+        } catch (e: Exception) {
+            Timber.e(e, "Could not schedule task ${schedule.id}")
+        }
+    }
+
+    fun cancel(context: Context, scheduleId: String) {
+        val alarmManager = alarmManager(context) ?: return
+        try {
+            alarmManager.cancel(pendingIntent(context, scheduleId))
+            Timber.d("Cancelled scheduled task $scheduleId")
+        } catch (e: Exception) {
+            Timber.e(e, "Could not cancel task $scheduleId")
+        }
+    }
+
+    /**
+     * Re-arms every enabled schedule and clears the alarms of the disabled ones.
+     */
+    fun scheduleAll(context: Context, repository: ScheduleRepository) {
+        for (schedule in repository.getAll()) {
+            if (schedule.enabled) {
+                schedule(context, schedule)
+            } else {
+                cancel(context, schedule.id)
+            }
+        }
+    }
+
+    private fun alarmManager(context: Context): AlarmManager? =
+        context.applicationContext.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+
+    private fun pendingIntent(context: Context, scheduleId: String): PendingIntent {
+        val intent = Intent(context.applicationContext, ScheduledTaskReceiver::class.java)
+        intent.putExtra(EXTRA_SCHEDULE_ID, scheduleId)
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        // The request code keeps each schedule's alarm distinct from the others.
+        return PendingIntent.getBroadcast(context.applicationContext, scheduleId.hashCode(), intent, flags)
+    }
+}

--- a/WallPanelPro/src/main/res/drawable/ic_baseline_add.xml
+++ b/WallPanelPro/src/main/res/drawable/ic_baseline_add.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2022 WallPanel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13h-6v6h-2v-6L5,13v-2h6L11,5h2v6h6v2z"/>
+</vector>

--- a/WallPanelPro/src/main/res/drawable/ic_baseline_delete.xml
+++ b/WallPanelPro/src/main/res/drawable/ic_baseline_delete.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2022 WallPanel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2L18,7L6,7v12zM19,4h-3.5l-1,-1h-5l-1,1L5,4v2h14L19,4z"/>
+</vector>

--- a/WallPanelPro/src/main/res/layout/dialog_edit_schedule.xml
+++ b/WallPanelPro/src/main/res/layout/dialog_edit_schedule.xml
@@ -1,0 +1,176 @@
+<!--
+  ~ Copyright (c) 2022 WallPanel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingTop="16dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="8dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/schedule_label_time"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+        <Button
+            android:id="@+id/scheduleTimeButton"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="-8dp"
+            android:textSize="24sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/schedule_label_days"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal">
+
+            <ToggleButton
+                android:id="@+id/scheduleDay0"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
+                android:textSize="11sp" />
+
+            <ToggleButton
+                android:id="@+id/scheduleDay1"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
+                android:textSize="11sp" />
+
+            <ToggleButton
+                android:id="@+id/scheduleDay2"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
+                android:textSize="11sp" />
+
+            <ToggleButton
+                android:id="@+id/scheduleDay3"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
+                android:textSize="11sp" />
+
+            <ToggleButton
+                android:id="@+id/scheduleDay4"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
+                android:textSize="11sp" />
+
+            <ToggleButton
+                android:id="@+id/scheduleDay5"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
+                android:textSize="11sp" />
+
+            <ToggleButton
+                android:id="@+id/scheduleDay6"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:minWidth="0dp"
+                android:paddingStart="0dp"
+                android:paddingEnd="0dp"
+                android:textSize="11sp" />
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/schedule_label_action"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+        <Spinner
+            android:id="@+id/scheduleActionSpinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:entries="@array/schedule_action_names" />
+
+        <EditText
+            android:id="@+id/schedulePayload"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="@string/schedule_hint_url"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:maxLines="2"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/scheduleShellWarning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/schedule_shell_disabled_warning"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="13sp"
+            android:visibility="gone" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/scheduleEnabledSwitch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/schedule_label_enabled" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/WallPanelPro/src/main/res/layout/dialog_edit_schedule.xml
+++ b/WallPanelPro/src/main/res/layout/dialog_edit_schedule.xml
@@ -36,10 +36,11 @@
 
         <Button
             android:id="@+id/scheduleTimeButton"
-            style="?android:attr/borderlessButtonStyle"
+            style="?attr/borderlessButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="-8dp"
+            android:textColor="?android:attr/textColorPrimary"
             android:textSize="24sp" />
 
         <TextView

--- a/WallPanelPro/src/main/res/layout/fragment_scheduled_tasks.xml
+++ b/WallPanelPro/src/main/res/layout/fragment_scheduled_tasks.xml
@@ -15,6 +15,7 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -23,7 +24,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:paddingBottom="16dp"
+        android:paddingBottom="88dp"
         android:scrollbars="vertical" />
 
     <TextView
@@ -37,5 +38,14 @@
         android:textColor="?android:attr/textColorSecondary"
         android:textSize="16sp"
         android:visibility="gone" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/addScheduleFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|start"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/menu_title_add_schedule"
+        app:srcCompat="@drawable/ic_baseline_add" />
 
 </FrameLayout>

--- a/WallPanelPro/src/main/res/layout/fragment_scheduled_tasks.xml
+++ b/WallPanelPro/src/main/res/layout/fragment_scheduled_tasks.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2022 WallPanel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/scheduleList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="16dp"
+        android:scrollbars="vertical" />
+
+    <TextView
+        android:id="@+id/scheduleEmptyText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="32dp"
+        android:text="@string/text_no_scheduled_tasks"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="16sp"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/WallPanelPro/src/main/res/layout/item_schedule.xml
+++ b/WallPanelPro/src/main/res/layout/item_schedule.xml
@@ -1,0 +1,73 @@
+<!--
+  ~ Copyright (c) 2022 WallPanel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scheduleRow"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:minHeight="72dp"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="8dp"
+    android:paddingBottom="8dp">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/scheduleTime"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="20sp"
+            tools:text="07:00" />
+
+        <TextView
+            android:id="@+id/scheduleSummary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="2dp"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="14sp" />
+
+    </LinearLayout>
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/scheduleEnabled"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp" />
+
+    <ImageButton
+        android:id="@+id/scheduleDelete"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="?android:attr/selectableItemBackground"
+        android:contentDescription="@string/content_description_delete_schedule"
+        android:src="@drawable/ic_baseline_delete"
+        app:tint="?android:attr/textColorSecondary" />
+
+</LinearLayout>

--- a/WallPanelPro/src/main/res/menu/menu_scheduled_tasks.xml
+++ b/WallPanelPro/src/main/res/menu/menu_scheduled_tasks.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2022 WallPanel
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_add_schedule"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/ic_baseline_add"
+        android:title="@string/menu_title_add_schedule">
+    </item>
+</menu>

--- a/WallPanelPro/src/main/res/menu/menu_scheduled_tasks.xml
+++ b/WallPanelPro/src/main/res/menu/menu_scheduled_tasks.xml
@@ -19,7 +19,7 @@
 
     <item
         android:id="@+id/action_add_schedule"
-        app:showAsAction="ifRoom"
+        app:showAsAction="always"
         android:icon="@drawable/ic_baseline_add"
         android:title="@string/menu_title_add_schedule">
     </item>

--- a/WallPanelPro/src/main/res/navigation/settings_nav_graph.xml
+++ b/WallPanelPro/src/main/res/navigation/settings_nav_graph.xml
@@ -22,6 +22,7 @@
         <action android:id="@+id/mqtt_action" app:destination="@id/mqtt_fragment"/>
         <action android:id="@+id/http_action" app:destination="@id/http_fragment"/>
         <action android:id="@+id/sensors_action" app:destination="@id/sensors_fragment"/>
+        <action android:id="@+id/scheduled_tasks_action" app:destination="@id/scheduled_tasks_fragment"/>
         <action android:id="@+id/about_action" app:destination="@id/about_fragment"/>
     </fragment>
 
@@ -58,6 +59,12 @@
     <fragment android:id="@+id/http_fragment"
         android:label="@string/title_http_settings"
         android:name="xyz.wallpanel.pro.ui.fragments.HttpSettingsFragment" >
+        <action android:id="@+id/settings_action" app:destination="@id/settings_fragment"/>
+    </fragment>
+
+    <fragment android:id="@+id/scheduled_tasks_fragment"
+        android:label="@string/title_scheduled_tasks"
+        android:name="xyz.wallpanel.pro.ui.fragments.ScheduledTasksFragment" >
         <action android:id="@+id/settings_action" app:destination="@id/settings_fragment"/>
     </fragment>
 

--- a/WallPanelPro/src/main/res/values-night/styles.xml
+++ b/WallPanelPro/src/main/res/values-night/styles.xml
@@ -44,6 +44,7 @@
         <item name="android:backgroundDimEnabled">false</item>
         <item name="buttonBarNegativeButtonStyle">@style/DialogButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/DialogButtonStyle</item>
+        <item name="buttonBarNeutralButtonStyle">@style/DialogButtonStyle</item>
         <item name="android:background">@color/dialogBackgroundColor</item>
     </style>
 

--- a/WallPanelPro/src/main/res/values/strings.xml
+++ b/WallPanelPro/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="toast_camera_permission_denied">Camera permission not granted.</string>
     <string name="toast_shell_permission_granted">Storage permission granted.</string>
     <string name="toast_shell_permission_denied">Storage permission not granted. Shell commands remain enabled, but commands that read or write shared storage may not work.</string>
+    <string name="toast_notification_permission_denied">Notification permission not granted. The application may stay closed after it restarts itself.</string>
     <string name="dialog_write_permissions_title">Permissions Required</string>
     <string name="dialog_write_permissions_description">Do you want to grant permission to modify the system settings for screen brightness?</string>
     <string name="pref_title_screen_brightness">Screen Brightness</string>
@@ -185,6 +186,10 @@
     <string name="error_mqtt_subscription">Couldn\'t subscribe to the MQTT topics, check the MQTT broker settings or your connection.</string>
     <string name="text_android_channel_name">WallPanel Pro Running</string>
     <string name="text_android_channel_description">WallPanel Pro Running…</string>
+    <string name="text_restart_channel_name">WallPanel Pro Restarting</string>
+    <string name="text_restart_channel_description">Reopens the dashboard after the application restarts.</string>
+    <string name="text_restart_notification_title">WallPanel Pro Restarting</string>
+    <string name="text_restart_notification_message">Tap to reopen the dashboard.</string>
     <string name="text_camera_front">Front</string>
     <string name="text_camera_back">Back</string>
     <string name="toast_camera_source_error">Could not start camera source, you may want to try again.</string>
@@ -336,6 +341,52 @@
     <string name="title_use_geckoview_suspend_seconds">GeckoView Background Suspend Delay</string>
     <string name="summary_use_geckoview_suspend_seconds">Suspends GeckoView to stop background CPU use after the screen has been off this many seconds. Currently %1$s. 0 disables suspension.</string>
 
+
+    <!-- Scheduled Tasks -->
+    <string name="key_setting_schedules">pref_scheduled_tasks</string>
+    <string name="title_scheduled_tasks">Scheduled Tasks</string>
+    <string name="summary_scheduled_tasks">Run an action at a set time on the days you choose.</string>
+    <string name="text_no_scheduled_tasks">No scheduled tasks yet. Use the + button to add one.</string>
+    <string name="menu_title_add_schedule">Add Task</string>
+    <string name="content_description_delete_schedule">Delete task</string>
+    <string name="dialog_title_add_schedule">Add Task</string>
+    <string name="dialog_title_edit_schedule">Edit Task</string>
+    <string name="schedule_label_time">Time</string>
+    <string name="schedule_label_days">Days</string>
+    <string name="schedule_label_action">Action</string>
+    <string name="schedule_label_enabled">Enabled</string>
+    <string name="schedule_hint_url">Dashboard or page URL</string>
+    <string name="schedule_hint_shell">Shell command</string>
+    <string name="schedule_summary_every_day">Every day</string>
+    <string name="schedule_summary_separator">" · "</string>
+    <string name="schedule_summary_disabled">Disabled</string>
+    <string name="schedule_time_format">%1$02d:%2$02d</string>
+    <string name="schedule_shell_disabled_warning">Shell commands are turned off. Turn on Shell Commands in HTTP Settings for this task to run.</string>
+    <string name="button_delete">Delete</string>
+    <string name="button_save">Save</string>
+    <string name="toast_schedule_saved">Task saved.</string>
+    <string name="toast_schedule_deleted">Task deleted.</string>
+    <string name="toast_schedule_no_days">Choose at least one day.</string>
+    <string name="toast_schedule_payload_required">Enter a value for this action.</string>
+
+    <string-array name="schedule_action_names">
+        <item>Restart Application</item>
+        <item>Reload Page</item>
+        <item>Clear Cache</item>
+        <item>Relaunch Dashboard</item>
+        <item>Browse To URL</item>
+        <item>Shell Command</item>
+    </string-array>
+
+    <string-array name="schedule_day_names_short">
+        <item>Sun</item>
+        <item>Mon</item>
+        <item>Tue</item>
+        <item>Wed</item>
+        <item>Thu</item>
+        <item>Fri</item>
+        <item>Sat</item>
+    </string-array>
 
     <string-array name="flip_directions">
         <item>None</item>

--- a/WallPanelPro/src/main/res/values/styles.xml
+++ b/WallPanelPro/src/main/res/values/styles.xml
@@ -42,6 +42,7 @@
         <item name="android:backgroundDimEnabled">false</item>
         <item name="buttonBarNegativeButtonStyle">@style/DialogButtonStyle</item>
         <item name="buttonBarPositiveButtonStyle">@style/DialogButtonStyle</item>
+        <item name="buttonBarNeutralButtonStyle">@style/DialogButtonStyle</item>
         <item name="android:background">@color/dialogBackgroundColor</item>
     </style>
 

--- a/WallPanelPro/src/main/res/xml/pref_general.xml
+++ b/WallPanelPro/src/main/res/xml/pref_general.xml
@@ -230,6 +230,11 @@
             android:key="button_key_sensors"
             android:title="@string/title_sensor_settings"/>
 
+        <Preference
+            android:key="button_key_scheduled_tasks"
+            android:title="@string/title_scheduled_tasks"
+            android:summary="@string/summary_scheduled_tasks"/>
+
     </PreferenceCategory>
 
     <Preference

--- a/WallPanelPro/src/test/java/xyz/wallpanel/pro/persistence/ScheduleRepositoryTest.kt
+++ b/WallPanelPro/src/test/java/xyz/wallpanel/pro/persistence/ScheduleRepositoryTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.persistence
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+
+/**
+ * Exercises [ScheduleRepository] against a real SharedPreferences under Robolectric, in the
+ * same shape as [ConfigurationTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+class ScheduleRepositoryTest {
+
+    private lateinit var context: Context
+    private lateinit var preferences: SharedPreferences
+    private lateinit var repository: ScheduleRepository
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        preferences.edit().clear().commit()
+        repository = ScheduleRepository(context, preferences)
+    }
+
+    @Test
+    fun `getAll is empty on a fresh install`() {
+        assertTrue(repository.getAll().isEmpty())
+    }
+
+    @Test
+    fun `saves and reads back a schedule`() {
+        val schedule = Schedule(hour = 7, minute = 0, action = ScheduleAction.RESTART_APP)
+
+        repository.save(schedule)
+
+        assertEquals(listOf(schedule), repository.getAll())
+    }
+
+    @Test
+    fun `saving keeps insertion order`() {
+        val first = Schedule(id = "first", hour = 7, minute = 0, action = ScheduleAction.RELOAD)
+        val second = Schedule(id = "second", hour = 8, minute = 0, action = ScheduleAction.CLEAR_CACHE)
+
+        repository.save(first)
+        repository.save(second)
+
+        assertEquals(listOf("first", "second"), repository.getAll().map { it.id })
+    }
+
+    @Test
+    fun `saving an existing id upserts rather than duplicating`() {
+        val schedule = Schedule(id = "same", hour = 7, minute = 0, action = ScheduleAction.RELOAD)
+        repository.save(schedule)
+
+        repository.save(schedule.copy(hour = 9, minute = 45, days = setOf(Calendar.MONDAY)))
+
+        val all = repository.getAll()
+        assertEquals(1, all.size)
+        assertEquals(9, all[0].hour)
+        assertEquals(45, all[0].minute)
+        assertEquals(setOf(Calendar.MONDAY), all[0].days)
+    }
+
+    @Test
+    fun `deletes by id and leaves the others alone`() {
+        repository.save(Schedule(id = "keep", hour = 7, minute = 0, action = ScheduleAction.RELOAD))
+        repository.save(Schedule(id = "drop", hour = 8, minute = 0, action = ScheduleAction.RELOAD))
+
+        repository.delete("drop")
+
+        assertEquals(listOf("keep"), repository.getAll().map { it.id })
+    }
+
+    @Test
+    fun `deleting an unknown id changes nothing`() {
+        repository.save(Schedule(id = "keep", hour = 7, minute = 0, action = ScheduleAction.RELOAD))
+
+        repository.delete("never-existed")
+
+        assertEquals(listOf("keep"), repository.getAll().map { it.id })
+    }
+
+    @Test
+    fun `getEnabled filters out disabled schedules`() {
+        repository.save(Schedule(id = "on", hour = 7, minute = 0, action = ScheduleAction.RELOAD))
+        repository.save(Schedule(id = "off", enabled = false, hour = 8, minute = 0, action = ScheduleAction.RELOAD))
+
+        assertEquals(listOf("on"), repository.getEnabled().map { it.id })
+    }
+
+    @Test
+    fun `a new repository instance sees the persisted schedules`() {
+        val schedule = Schedule(id = "persisted", hour = 6, minute = 30, action = ScheduleAction.URL, payload = "https://wallpanel.xyz")
+        repository.save(schedule)
+
+        // Confirms the write actually landed in preferences rather than in-memory state.
+        assertEquals(listOf(schedule), ScheduleRepository(context, preferences).getAll())
+    }
+}

--- a/WallPanelPro/src/test/java/xyz/wallpanel/pro/persistence/ScheduleSerializerTest.kt
+++ b/WallPanelPro/src/test/java/xyz/wallpanel/pro/persistence/ScheduleSerializerTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.persistence
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Calendar
+
+/**
+ * Covers the JSON encoding of scheduled tasks. Runs on the JVM against the real org.json,
+ * no emulator and no Robolectric.
+ */
+class ScheduleSerializerTest {
+
+    @Test
+    fun `round-trips a single schedule`() {
+        val schedule = Schedule(
+            id = "abc-123",
+            enabled = false,
+            hour = 7,
+            minute = 5,
+            days = setOf(Calendar.MONDAY, Calendar.FRIDAY),
+            action = ScheduleAction.URL,
+            payload = "https://wallpanel.xyz"
+        )
+
+        val decoded = ScheduleSerializer.fromJsonArray(ScheduleSerializer.toJsonArray(listOf(schedule)))
+
+        assertEquals(listOf(schedule), decoded)
+    }
+
+    @Test
+    fun `round-trips many schedules and preserves order`() {
+        val schedules = listOf(
+            Schedule(id = "one", hour = 6, minute = 0, action = ScheduleAction.RESTART_APP),
+            Schedule(id = "two", hour = 12, minute = 30, action = ScheduleAction.RELOAD),
+            Schedule(id = "three", hour = 23, minute = 59, action = ScheduleAction.SHELL, payload = "echo hi")
+        )
+
+        val decoded = ScheduleSerializer.fromJsonArray(ScheduleSerializer.toJsonArray(schedules))
+
+        assertEquals(schedules, decoded)
+        assertEquals(listOf("one", "two", "three"), decoded.map { it.id })
+    }
+
+    @Test
+    fun `skips an entry with an unrecognized action instead of throwing`() {
+        val json = JSONArray()
+        json.put(
+            JSONObject()
+                .put("id", "future")
+                .put("hour", 8)
+                .put("minute", 0)
+                .put("action", "somethingFromANewerVersion")
+        )
+        json.put(
+            JSONObject()
+                .put("id", "known")
+                .put("hour", 9)
+                .put("minute", 15)
+                .put("action", "reload")
+        )
+
+        val decoded = ScheduleSerializer.fromJsonArray(json.toString())
+
+        assertEquals(1, decoded.size)
+        assertEquals("known", decoded[0].id)
+        assertEquals(ScheduleAction.RELOAD, decoded[0].action)
+    }
+
+    @Test
+    fun `applies defaults for fields omitted from the json`() {
+        val json = JSONArray().put(
+            JSONObject()
+                .put("id", "minimal")
+                .put("hour", 22)
+                .put("minute", 45)
+                .put("action", "clearCache")
+        )
+
+        val decoded = ScheduleSerializer.fromJsonArray(json.toString())
+
+        assertEquals(1, decoded.size)
+        val schedule = decoded[0]
+        assertTrue(schedule.enabled)
+        assertEquals(Schedule.ALL_DAYS, schedule.days)
+        assertEquals("", schedule.payload)
+    }
+
+    @Test
+    fun `defaults survive a round trip`() {
+        val schedule = Schedule(id = "defaults", hour = 3, minute = 0, action = ScheduleAction.RELAUNCH)
+
+        val decoded = ScheduleSerializer.fromJsonArray(ScheduleSerializer.toJsonArray(listOf(schedule)))
+
+        assertEquals(listOf(schedule), decoded)
+        assertTrue(decoded[0].enabled)
+        assertEquals(Schedule.ALL_DAYS, decoded[0].days)
+        assertEquals("", decoded[0].payload)
+    }
+
+    @Test
+    fun `an explicitly empty day set is not replaced by the default`() {
+        val json = JSONArray().put(
+            JSONObject()
+                .put("id", "nodays")
+                .put("hour", 1)
+                .put("minute", 0)
+                .put("days", JSONArray())
+                .put("action", "reload")
+        )
+
+        val decoded = ScheduleSerializer.fromJsonArray(json.toString())
+
+        assertEquals(emptySet<Int>(), decoded[0].days)
+    }
+
+    @Test
+    fun `an empty list encodes and decodes to an empty list`() {
+        assertEquals(emptyList<Schedule>(), ScheduleSerializer.fromJsonArray(ScheduleSerializer.toJsonArray(emptyList())))
+    }
+
+    @Test
+    fun `malformed json decodes to an empty list instead of throwing`() {
+        assertEquals(emptyList<Schedule>(), ScheduleSerializer.fromJsonArray("not json at all"))
+        assertEquals(emptyList<Schedule>(), ScheduleSerializer.fromJsonArray(""))
+    }
+}

--- a/WallPanelPro/src/test/java/xyz/wallpanel/pro/utils/ScheduledTaskAlarmSchedulerTest.kt
+++ b/WallPanelPro/src/test/java/xyz/wallpanel/pro/utils/ScheduledTaskAlarmSchedulerTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022 WallPanel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.wallpanel.pro.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import xyz.wallpanel.pro.persistence.Schedule
+import xyz.wallpanel.pro.persistence.ScheduleAction
+import java.util.Calendar
+import java.util.TimeZone
+
+/**
+ * Covers the trigger-time maths of the task scheduler. This is the pure part, so it runs on
+ * the JVM with a fixed time zone and no Android framework.
+ */
+class ScheduledTaskAlarmSchedulerTest {
+
+    private val zone: TimeZone = TimeZone.getTimeZone("UTC")
+
+    // 1 January 2024 is a Monday, which keeps the weekday expectations below readable.
+    private fun at(day: Int, hour: Int, minute: Int): Long {
+        val calendar = Calendar.getInstance(zone)
+        calendar.clear()
+        calendar.set(2024, Calendar.JANUARY, day, hour, minute, 0)
+        return calendar.timeInMillis
+    }
+
+    private fun schedule(
+        hour: Int,
+        minute: Int,
+        days: Set<Int> = Schedule.ALL_DAYS,
+        enabled: Boolean = true
+    ) = Schedule(
+        id = "test",
+        enabled = enabled,
+        hour = hour,
+        minute = minute,
+        days = days,
+        action = ScheduleAction.RELOAD
+    )
+
+    @Test
+    fun `a time later today fires today`() {
+        val now = at(1, 8, 0)
+
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(schedule(9, 30), now, zone)
+
+        assertEquals(at(1, 9, 30), next)
+    }
+
+    @Test
+    fun `a time that has already passed fires tomorrow`() {
+        val now = at(1, 10, 0)
+
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(schedule(9, 30), now, zone)
+
+        assertEquals(at(2, 9, 30), next)
+    }
+
+    @Test
+    fun `now exactly at the scheduled instant counts as already passed`() {
+        val now = at(1, 9, 30)
+
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(schedule(9, 30), now, zone)
+
+        assertEquals(at(2, 9, 30), next)
+    }
+
+    @Test
+    fun `a single weekday fires on the next matching day`() {
+        // Monday 1 January, looking for Wednesday.
+        val now = at(1, 8, 0)
+
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(
+            schedule(9, 30, days = setOf(Calendar.WEDNESDAY)), now, zone
+        )
+
+        assertEquals(at(3, 9, 30), next)
+    }
+
+    @Test
+    fun `a saturday-only schedule wraps into the following week`() {
+        // Saturday 6 January, after the scheduled time.
+        val now = at(6, 10, 0)
+
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(
+            schedule(9, 30, days = setOf(Calendar.SATURDAY)), now, zone
+        )
+
+        assertEquals(at(13, 9, 30), next)
+    }
+
+    @Test
+    fun `a saturday-only schedule still fires today when the time is ahead`() {
+        val now = at(6, 8, 0)
+
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(
+            schedule(9, 30, days = setOf(Calendar.SATURDAY)), now, zone
+        )
+
+        assertEquals(at(6, 9, 30), next)
+    }
+
+    @Test
+    fun `a disabled schedule never triggers`() {
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(
+            schedule(9, 30, enabled = false), at(1, 8, 0), zone
+        )
+
+        assertNull(next)
+    }
+
+    @Test
+    fun `a schedule with no days never triggers`() {
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(
+            schedule(9, 30, days = emptySet()), at(1, 8, 0), zone
+        )
+
+        assertNull(next)
+    }
+
+    @Test
+    fun `midnight on a weekday-only schedule resolves to the start of that day`() {
+        // Friday 5 January at 23:00, weekdays only, so the next slot is Monday 8 January.
+        val now = at(5, 23, 0)
+
+        val next = ScheduledTaskAlarmScheduler.nextTriggerMillis(
+            schedule(
+                0, 0,
+                days = setOf(
+                    Calendar.MONDAY, Calendar.TUESDAY, Calendar.WEDNESDAY,
+                    Calendar.THURSDAY, Calendar.FRIDAY
+                )
+            ),
+            now, zone
+        )
+
+        assertEquals(at(8, 0, 0), next)
+    }
+}

--- a/website/docs/remote-control/commands.md
+++ b/website/docs/remote-control/commands.md
@@ -13,6 +13,7 @@ eval | JavaScript | ```{"eval": "alert('Hello World!');"}``` | Evaluates Javascr
 audio | URL | ```{"audio": "http://<url>"}``` | Play the audio specified by the URL immediately
 relaunch | true | ```{"relaunch": true}``` | Relaunches the dashboard from configured launchUrl
 reload | true | ```{"reload": true}``` | Reloads the current page immediately
+restartApp | true | ```{"restartApp": true}``` | Restarts the WallPanel app (kills and relaunches the process) -- this is not a device reboot
 url | URL | ```{"url": "http://<url>"}``` | Browse to a new URL immediately
 wake | true | ```{"wake": true, "wakeTime": 180}``` | Wakes the screen if it is asleep. Optional wakeTime (in seconds). If no wake time provided, screen will wake but return to screensaver mode on user inactivity.  Sending false value will return app to normal screensaver mode and display screensaver on user inactivity.
 wake | false | ```{"wake": false}``` | Release screen wake (Note: screen will not turn off before Androids Display Timeout finished)

--- a/website/docs/scheduled-tasks.md
+++ b/website/docs/scheduled-tasks.md
@@ -1,0 +1,61 @@
+---
+title: Scheduled Tasks
+---
+
+Scheduled Tasks let the device run an action on its own, at a time of day and on the
+days you choose, without anything sending it a command. This is useful when you want
+the kiosk to reload, switch dashboards, or restart itself on a routine, even if your
+home automation system or network is unreachable at the time -- the schedule fires
+locally and dispatches through the same command handling MQTT and HTTP commands
+already use.
+
+WallPanel is a general kiosk browser, not a Home Assistant-only tool, so a schedule can
+point at any URL -- a different dashboard in the morning, a different website in the
+evening, a status page overnight, and so on.
+
+## Adding a task
+
+Go to **Settings &rarr; Scheduled Tasks**. The screen lists your existing tasks; tap the
+**+** button to add a new one. Each task has:
+
+- **Enabled** -- switch a task off without deleting it.
+- **Time** -- tap the time to open the time picker.
+- **Days** -- toggle any combination of days of the week. There is no separate "every
+  day" option; selecting all seven days is the same as "every day," and at least one day
+  must be selected before the task can be saved.
+- **Action** -- one of the six actions below.
+
+Tap an existing task to edit it, or use its delete button to remove it. Turning a task
+off (or deleting it) cancels the alarm backing it; saving a task arms (or re-arms) the
+alarm for its next matching day and time.
+
+## Actions
+
+- **Restart Application** -- kills and relaunches the WallPanel process. WallPanel has
+  no root access and isn't provisioned as a device owner, so it cannot trigger an actual
+  OS-level reboot; restarting the app itself is the closest equivalent. This is the same
+  action as the standalone [`restartApp`](./remote-control/commands.md) MQTT/HTTP
+  command.
+- **Reload Page** -- reloads the current page, same as the `reload` command.
+- **Clear Cache** -- clears the browser cache, same as the `clearCache` command.
+- **Relaunch Dashboard** -- browses back to the configured launch URL, same as the
+  `relaunch` command.
+- **Browse To URL** -- browses to a URL you enter when creating the task, same as the
+  `url` command. Use this to switch to a different dashboard or website at a set time.
+- **Shell Command** -- runs a shell command you enter when creating the task, same as
+  the `shell` command. This only works if **Settings &rarr; HTTP &rarr; Enable Shell
+  Commands** is turned on; if it's off, the task editor shows a warning and the task
+  will not run until you enable it. See [Shell Command](./remote-control/commands.md#shell-command)
+  for what the command can and cannot do -- it runs unprivileged, with no root, exactly
+  the same as when it's triggered over MQTT or HTTP.
+
+## Timing
+
+Tasks are scheduled with an inexact Android alarm, so a task can fire a few minutes
+after its set time rather than exactly on it. This is deliberate: an exact alarm would
+require a runtime permission prompt on Android 12 and above, which WallPanel avoids.
+For actions like reloading a page or switching dashboards, firing a few minutes late is
+an acceptable trade-off.
+
+Scheduled tasks survive a device reboot -- they are re-armed automatically when
+WallPanel starts back up.


### PR DESCRIPTION
## Summary

### Scheduled Tasks
Adds a new settings screen where you can create, edit, and delete scheduled tasks. Each task can run at a specific time on selected days of the week and perform one of six actions:

  - Restart the app
  - Reload the page
  - Clear the cache
  - Relaunch the dashboard
  - Open a URL
  - Run a shell command

Scheduled tasks use Android's alarm system, continue working after a device restart, and use the same command system already used by MQTT and HTTP.

### Restart App command
Adds a new `restartApp` command for MQTT and HTTP. This completely closes and reopens the app, but **does not reboot the Android device**.

### Fixed
**REST API setting now works immediately:** Disabling **Enable REST API** in Settings now takes effect immediately. Previously, the API could remain accessible until the HTTP server was restarted. Disabled requests now return `403 Forbidden`.

### Documentation
Added documentation for Scheduled Tasks and the new `restartApp` command.
