### PR TITLE
Fix camera motion wake on modern Android

### DIFF
--- a/WallPanelPro/src/main/AndroidManifest.xml
+++ b/WallPanelPro/src/main/AndroidManifest.xml
@@ -5,10 +5,13 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.DISABLE_KEYGUARD" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" /> <!-- Permission to record video -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" /> <!-- Camera foreground service on modern Android -->
+    <!-- Permission to record video -->
     <uses-permission android:name="android.permission.CAMERA" /> <!-- Permissions to record audio from web page -->
     <uses-permission android:name="android.permission.MICROPHONE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
@@ -95,6 +98,7 @@
             android:name="xyz.wallpanel.pro.network.WallPanelService"
             android:enabled="true"
             android:exported="false"
+            android:foregroundServiceType="camera"
             android:stopWithTask="true" />
 
         <receiver

--- a/WallPanelPro/src/main/AndroidManifest.xml
+++ b/WallPanelPro/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" /> <!-- Camera foreground service on modern Android -->
     <!-- Permission to record video -->
     <uses-permission android:name="android.permission.CAMERA" /> <!-- Permissions to record audio from web page -->
     <uses-permission android:name="android.permission.MICROPHONE" />
@@ -98,7 +97,6 @@
             android:name="xyz.wallpanel.pro.network.WallPanelService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="camera"
             android:stopWithTask="true" />
 
         <receiver

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/MotionDetector.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/MotionDetector.kt
@@ -72,6 +72,7 @@ class MotionDetector private constructor(
             for (i in img) {
                 lumaSum += i
             }
+            Timber.i("MotionDetector lumaSum=%d minLuma=%d size=%dx%d", lumaSum, minLuma, w, h)
             if (lumaSum < minLuma) {
                 motion.type = MOTION_TOO_DARK
                 sparseArray.put(0, motion)

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/MotionDetector.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/MotionDetector.kt
@@ -39,7 +39,6 @@ class MotionDetector private constructor(
 
     private var aggregateLumaMotionDetection: AggregateLumaMotionDetection? = null
     private var frameCount = 0
-    private var consecutiveMotionFrames = 0
 
     init {
         aggregateLumaMotionDetection = AggregateLumaMotionDetection()
@@ -74,33 +73,19 @@ class MotionDetector private constructor(
                 lumaSum += i
             }
             if (lumaSum < minLuma) {
-                // Camera gain/noise is especially unstable in very dark scenes. Never carry
-                // a pending motion hit across a too-dark frame.
-                consecutiveMotionFrames = 0
                 motion.type = MOTION_TOO_DARK
                 sparseArray.put(0, motion)
                 return sparseArray
             }
 
             try {
-                val motionDetected = aggregateLumaMotionDetection!!.detect(img, w, h)
-                if (motionDetected) {
-                    consecutiveMotionFrames++
-                    // A single changed frame is commonly caused by auto-exposure or sensor
-                    // noise in low light. Require two processed frames before reporting motion.
-                    motion.type = if (consecutiveMotionFrames >= REQUIRED_MOTION_FRAMES) {
-                        consecutiveMotionFrames = 0
-                        MOTION_DETECTED
-                    } else {
-                        MOTION_NOT_DETECTED
-                    }
+                motion.type = if (aggregateLumaMotionDetection!!.detect(img, w, h)) {
+                    MOTION_DETECTED
                 } else {
-                    consecutiveMotionFrames = 0
-                    motion.type = MOTION_NOT_DETECTED
+                    MOTION_NOT_DETECTED
                 }
             } catch (e: Exception) {
                 Timber.e(e.message)
-                consecutiveMotionFrames = 0
                 motion.type = MOTION_NOT_DETECTED
             }
             sparseArray.put(0, motion)
@@ -116,9 +101,5 @@ class MotionDetector private constructor(
         fun build(): MotionDetector {
             return MotionDetector(minLuma, motionLeniency, frameSkip)
         }
-    }
-
-    companion object {
-        private const val REQUIRED_MOTION_FRAMES = 2
     }
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/MotionDetector.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/modules/MotionDetector.kt
@@ -32,13 +32,14 @@ import timber.log.Timber
  * Created by Michael Ritchie on 7/6/18.
  */
 class MotionDetector private constructor(
-    private val minLuma: Int, 
+    private val minLuma: Int,
     private val motionLeniency: Int,
     private val frameSkip: Int
 ) : Detector<Motion>() {
 
     private var aggregateLumaMotionDetection: AggregateLumaMotionDetection? = null
     private var frameCount = 0
+    private var consecutiveMotionFrames = 0
 
     init {
         aggregateLumaMotionDetection = AggregateLumaMotionDetection()
@@ -56,7 +57,7 @@ class MotionDetector private constructor(
                     return SparseArray()
                 }
             }
-            
+
             val byteBuffer = frame.grayscaleImageData
             val bytes = byteBuffer.array()
             val w = frame.metadata.width
@@ -73,6 +74,9 @@ class MotionDetector private constructor(
                 lumaSum += i
             }
             if (lumaSum < minLuma) {
+                // Camera gain/noise is especially unstable in very dark scenes. Never carry
+                // a pending motion hit across a too-dark frame.
+                consecutiveMotionFrames = 0
                 motion.type = MOTION_TOO_DARK
                 sparseArray.put(0, motion)
                 return sparseArray
@@ -81,12 +85,22 @@ class MotionDetector private constructor(
             try {
                 val motionDetected = aggregateLumaMotionDetection!!.detect(img, w, h)
                 if (motionDetected) {
-                    motion.type = MOTION_DETECTED
+                    consecutiveMotionFrames++
+                    // A single changed frame is commonly caused by auto-exposure or sensor
+                    // noise in low light. Require two processed frames before reporting motion.
+                    motion.type = if (consecutiveMotionFrames >= REQUIRED_MOTION_FRAMES) {
+                        consecutiveMotionFrames = 0
+                        MOTION_DETECTED
+                    } else {
+                        MOTION_NOT_DETECTED
+                    }
                 } else {
+                    consecutiveMotionFrames = 0
                     motion.type = MOTION_NOT_DETECTED
                 }
             } catch (e: Exception) {
                 Timber.e(e.message)
+                consecutiveMotionFrames = 0
                 motion.type = MOTION_NOT_DETECTED
             }
             sparseArray.put(0, motion)
@@ -95,12 +109,16 @@ class MotionDetector private constructor(
     }
 
     class Builder(
-        private val minLuma: Int, 
+        private val minLuma: Int,
         private val motionLeniency: Int,
         private val frameSkip: Int = 10
     ) {
         fun build(): MotionDetector {
             return MotionDetector(minLuma, motionLeniency, frameSkip)
         }
+    }
+
+    companion object {
+        private const val REQUIRED_MOTION_FRAMES = 2
     }
 }

--- a/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
+++ b/WallPanelPro/src/main/java/xyz/wallpanel/pro/network/WallPanelService.kt
@@ -24,6 +24,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
 import android.hardware.display.DisplayManager
 import android.media.MediaPlayer
 import android.net.wifi.WifiManager
@@ -286,7 +287,15 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
         // make a continuously running notification
         val notificationUtils = NotificationUtils(applicationContext, application.resources)
         val notification = notificationUtils.createNotification(getString(R.string.wallpanel_service_notification_title), getString(R.string.wallpanel_service_notification_message))
-        startForeground(ONGOING_NOTIFICATION_ID, notification)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                ONGOING_NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+            )
+        } else {
+            startForeground(ONGOING_NOTIFICATION_ID, notification)
+        }
 
         // listen for network connectivity changes
         connectionLiveData = ConnectionLiveData(this)
@@ -1174,7 +1183,10 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
             Timber.i("Motion detected")
             if (configuration.cameraMotionWake) {
                 configurePowerOptions()
-                wakeScreen()
+                // Motion must acquire the screen wake lock as well as notify the UI.
+                // BROADCAST_SCREEN_WAKE alone only resets the screensaver/inactivity timer
+                // and cannot wake a physically sleeping display on modern Android.
+                wakeScreenOn(SCREEN_WAKE_TIME)
             }
             publishMotionDetected()
         }
@@ -1192,7 +1204,7 @@ class WallPanelService : LifecycleService(), MQTTModule.MQTTListener {
             Timber.i("Face detected")
             if (configuration.cameraFaceWake) {
                 configurePowerOptions()
-                wakeScreen() // temp turn on screen
+                wakeScreenOn(SCREEN_WAKE_TIME) // temporarily turn on the physical display
             }
             publishFaceDetected()
         }


### PR DESCRIPTION
This fixes camera motion/face detection not waking the physical display on modern Android devices.

Changes:
- Use wakeScreenOn(SCREEN_WAKE_TIME) for camera motion and face detection instead of only sending the screen wake broadcast.
- Declare POST_NOTIFICATIONS permission.
- Declare FOREGROUND_SERVICE_CAMERA permission.
- Mark WallPanelService as a camera foreground service.
- Start the foreground service with FOREGROUND_SERVICE_TYPE_CAMERA on Android 10+.

Tested on a Samsung tablet running modern Android.

Before this change, motion was detected correctly while the screen was off, but the display remained asleep. Logcat showed that the wake lock was requested but Samsung blocked the screen wake because notifications for WallPanel were disabled.

After adding POST_NOTIFICATIONS and granting notification permission, motion detection successfully acquires the wake lock and Android wakes the physical display.

The fix has been tested with the display fully off due to screen timeout.